### PR TITLE
docs(readme): "완료 알림" 섹션을 v1.5.0 active-notify 동작에 맞게 갱신

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Engineering workflow commands for Claude Code.
 
 ```bash
 brew install terminal-notifier
-brew install jq   # Stop hook 의존성
+brew install jq   # PreToolUse hook 의존성
 ```
 
 **2단계 — 자연어 요청**:
 
-- **단발 알림** — `"끝나면 알림 한 번 줘"`, `"ping me when this finishes"`. 다음 작업 완료 시 1회.
-- **반복 알림** — `"매 커맨드 끝날 때마다 알려줘"`, `"each time a step finishes, ping me"`. 매 turn 종료 시 발송, `"알림 취소"`로 중단할 때까지 (자동 횟수 제한 없음).
+- **단발 알림** — `"끝나면 알림 한 번 줘"`, `"ping me when this finishes"`. 사용자가 지정한 시점(작업 완료 등)에 모델이 알림을 1회 발송합니다. `"시작할 때랑 끝날 때 알려줘"`, `"start, midpoint, finish — ping each time"`처럼 여러 시점을 함께 지정하면 각 시점마다 발송합니다.
+- **반복 알림** — `"매 커맨드 끝날 때마다 알려줘"`, `"each time a step finishes, ping me"`. 모델이 매 turn 종료 직전 자체적으로 알림을 발송합니다 (`"알림 취소"`로 중단할 때까지). hook이 아닌 모델 판단 기반이라, 모델이 turn 끝의 호출을 놓치면 해당 turn 알림이 누락될 수 있습니다.
 
-**3단계 — 최초 macOS 권한 승인** (1단계 완료 후): 첫 알림 시 macOS 권한 다이얼로그가 표시됩니다. 미리 트리거하려면 `"알림 테스트 한 번 해줘"`로 발화하여 테스트 알림을 받고 **허용**을 클릭하세요. (Claude Code의 Bash 권한 다이얼로그는 PreToolUse hook이 자동 승인하므로 표시되지 않습니다 — macOS 알림 권한 다이얼로그만 1회 응답하면 됩니다.) 다이얼로그를 놓쳤다면 시스템 설정 → 알림 → terminal-notifier에서 수동 활성화. 권한 거부 후 복구는 셸에서 `terminal-notifier -message 'cc-cmds permission test' -title '[cc-cmds] test' -group cc-cmds-active-notify -execute ':'` 직접 실행으로 재트리거 (스킬 bypass와 동일 형식이라 banner 외관이 일치).
+**3단계 — 최초 macOS 권한 승인** (1단계 완료 후): 첫 알림 시 macOS 권한 다이얼로그가 표시됩니다. 미리 트리거하려면 `"알림 테스트 한 번 해줘"`로 발화하여 테스트 알림을 받고 **허용**을 클릭하세요. (Claude Code의 Bash 권한 다이얼로그는 플러그인의 PreToolUse hook이 자동 승인하므로 표시되지 않습니다 — macOS 알림 권한 다이얼로그만 1회 응답하면 됩니다.) 다이얼로그를 놓쳤다면 시스템 설정 → 알림 → terminal-notifier에서 수동 활성화. 권한 거부 후 복구는 셸에서 `terminal-notifier -message 'cc-cmds permission test' -title '[cc-cmds] test' -group cc-cmds-active-notify -execute ':'` 직접 실행으로 재트리거 (스킬 bypass와 동일 형식이라 banner 외관이 일치).
 
 terminal-notifier가 없거나 macOS가 아니면 알림은 오류 없이 비활성화됩니다.
 


### PR DESCRIPTION
## 배경

README "완료 알림 (선택)" 섹션이 v1.5.0(PR #11) 이전의 hook-driven hybrid 표현을 일부 잔존시켜, 외부 사용자 입장에서 실제 동작과 어긋나고 잘못된 mental model을 제공하던 문제를 수정한다.

v1.5.0에서 active-notify는 Stop hook + HTML-comment marker scrape 메커니즘이 제거되고 model-driven fire-now 단일 dispatch surface로 재설계됐으나, README 문구는 갱신되지 않았다.

## 변경 내용

- **jq 의존성 주석** — `# Stop hook 의존성` → `# PreToolUse hook 의존성`. v1.5.0에서 Stop hook은 제거됐고, jq는 PreToolUse hook(`active-notify-pretool.sh`)에서만 사용된다. 디스패처 스크립트(`notify.sh`)는 jq를 쓰지 않는다.
- **단발 알림** — "다음 작업 완료 시 1회"를 모델이 사용자 지정 시점에 발송하는 동작으로 reword하고, multi-sub-event 발화 예시(`"시작할 때랑 끝날 때 알려줘"`, `"start, midpoint, finish — ping each time"`)를 추가. 단발 모드도 여러 시점 지정 시 각 시점마다 발송 가능하나, 사용자가 README만 보고는 이를 표현하지 못하던 공백을 해소.
- **반복 알림** — "매 turn 종료 시 발송"(Stop hook 시절의 hook-driven 어휘)을 모델이 turn 종료 직전 자체 호출로 발송하는 model-driven 메커니즘으로 정정. hook이 아닌 모델 판단 기반이라 모델이 호출을 놓치면 해당 turn 알림이 누락될 수 있음을 명시하여, 사용자가 문제 발생 시 올바른 원인 위치를 찾도록 했다.
- **권한 승인 문단** — Bash 권한 다이얼로그 자동 승인 주체가 플러그인의 PreToolUse hook임을 명시.

## 비고

- README "완료 알림" 섹션은 수기 관리 구간(자동 생성 블록 외부)이라 `generate-readme.sh`가 건드리지 않으며, `make check`의 lint·readme 재생성은 추가 drift 없이 통과한다.
- README.md만 변경하는 문서 수정이므로 `plugin.json` 버전 bump 및 CHANGELOG entry 대상이 아니다.

Closes #15