### PR TITLE
fix(active-notify): task 완료 turn에서 fire-now를 첫 도구 호출로 의무화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-05-21
+
+`active-notify` v1.5.0이 ARM 후 background task 완료를 처리하는 turn에서 dispatch 순서를 강제하지 않아, 모델이 결과 검증(`find`/`grep` over logs 등)을 `fire-now`보다 먼저 호출하면 사용자 allowlist에 없는 명령이 권한 다이얼로그를 띄워 turn이 정지하고 알림이 미발송되던 결함을 수정한다. 사용자는 키보드 앞을 떠나 알림을 기다리던 중이라 알림도 chat 응답도 없는 무한 hang으로 인식한다. 본 릴리스는 SKILL.md / `_common/notify.md` 프로즈만 보강(코드·hook·frontmatter 미수정)하여 task 완료를 인지한 turn에서 `fire-now`를 첫 도구 호출로 의무화한다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Fixed
+
+- `active-notify` SKILL.md에 "Fire-now ordering within the turn (fire-first mandate)" 절 신설. 활성 ARM이 대상으로 하는 milestone 완료를 관찰한 직후 모델의 다음 도구 호출은 무조건 `notify.sh fire-now`여야 한다. fire-now는 plugin의 PreToolUse hook이 자동 승인하므로 권한 다이얼로그를 일으키지 않는 유일한 호출이며, 모델은 사용자 allowlist를 예측할 수 없으므로 "권한 게이트 호출보다 먼저"가 아니라 "어떤 호출보다도 먼저"여야 실행 가능한 규칙이 된다. observation이 turn 시작 시점에 이미 context에 있는 경우(background task 완료로 인한 re-invoke)와 mid-turn에 드러나는 경우(foreground Bash inline 종료, BashOutput poll) 모두 적용된다. 실패한 task에서도 동일 순서 — 조사 욕구가 강한 함정 지점이지만 fire-now 먼저, 조사는 뒤.
+- "Defensive fire-now (when an ARM may be live)" 절 신설. long task 끝에 ARM 발화 기억이 context에서 사라졌더라도 ARM이 placed되지 않았다고 확실히 배제할 수 없다면 fire-now 먼저 호출한다. flag가 ground truth이며 dispatcher는 flag 부재 시 silent no-op이라 잘못된 호출은 무해하다. flag 파일을 Read해서 의문을 해소하지 말 것 — 그 Read 자체가 권한 게이트 호출이라 turn을 정지시킬 수 있다.
+- 새 worked example "Background-task completion — fire-first ordering" 추가. 안드로이드 빌드 background → 완료 → fire-now 첫 호출 → 그 다음 검증 패턴 시연. failed-build + mid-turn-observation variant 포함.
+- fire-now anti-pattern 정밀화 — "fire-now without ARM"을 "positively know no ARM was ever placed"로 재작성. ARM 기억 부재(uncertainty)와 ARM 부재 확실성(knowledge)을 구분하여, 전자는 defensive fire-now로 라우팅되고 후자만 금지된다. 추가 항목 "fire-now deferred behind another tool call" 신설 — 검증·점검 호출을 fire-now보다 앞 순서에 놓으면 권한 다이얼로그가 turn을 정지시켜 알림이 strand된다는 사례를 본문에 명시.
+- `_common/notify.md` "Notification fire" 절에 fire-first 문단 + copy 합성 보강. 검증 호출로 summary를 만들지 않고 이미 context에 있는 완료 신호(exit code, output tail)로 합성한다.
+
+### Why
+
+prose-only 보강만 적용한 이유: hook 기반 구조적 안전망(harness-driven turn-end fire 또는 권한 다이얼로그 이벤트를 정조준한 backstop)도 검토했으나, 모든 게이팅 옵션이 소음 대 복잡도 trade-off에서 만족스럽지 않았고 명시적으로 모델 판단에 위임된 결정에는 prose-only fence가 적절한 수단이라는 기존 방침을 따랐다. dogfood로 hang 재발 여부를 관찰한 뒤 hook 기반 backstop 도입 여부를 재검토할 예정. 환원 불가능한 잔여는 "모델이 task 완료를 처리하면서 fire-first/defensive-fire 규칙을 아예 떠올리지 않는 경우" — prose는 규칙을 명시할 수 있어도 모델이 그 규칙을 참조하도록 보장할 수 없는 갭이다.
+
+### Post-install notes
+
+- 외부 사용자 조치 불필요. `/plugin update cc-cmds`로 자동 반영.
+- frontmatter 미수정 → README diff 0, lint 회귀 없음. `make check` lint 5종 + readme parity 통과.
+- 코드(`notify.sh`)·hook(`active-notify-pretool.sh`)·flag schema 미변경. v1.5.0과 wire 호환 (기존 ARM flag 그대로 동작).
+
 ## [1.5.0] - 2026-05-21
 
 cc-cmds의 첫 model-invocable helper skill `active-notify`를 도입한다. 사용자가 자연어로 알림 발동을 요청하면 (`"끝나면 알려줘"`, `"매 작업마다 알려줘"`, `"시작할때랑 끝날때 알려줘"`) 모델이 ARM 상태를 TMPDIR JSON flag로 등록하고, 후속 sub-event 시점마다 모델이 직접 `notify.sh fire-now <workflow> <summary>`를 호출해 macOS `terminal-notifier`로 데스크탑 banner를 발화한다. plugin-level PreToolUse hook이 dispatcher Bash 호출을 session-persistent `applyPermissionRules`로 자동 승인하여 권한 다이얼로그 0건 불변식을 유지하며, ARM JSON schema:3 + `--count=N` flag로 single 모드 multi-sub-event 발화(`"시작할 때랑 끝날 때"` → `--count=2`)를 자연어 그대로 인코딩한다. macOS Notification Center가 banner에 자동 부착하던 "보기" 버튼이 click 시 부모 subshell focus를 가로채던 결함도 `-execute ':'` no-op click-target으로 차단한다 (`/plugin update cc-cmds`로 자동 반영).

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/_common/notify.md
+++ b/plugins/cc-cmds/skills/_common/notify.md
@@ -38,9 +38,19 @@ ARM → FIRE-NOW(s) → CANCEL/consume.
 
 ## §2 Notification fire
   fire-now is the **only** dispatch surface — model-driven, called at
-  each sub-event observation point. Banner copy is supplied verbatim
+  each sub-event observation point.
+  The moment the model observes an armed milestone complete, fire-now is
+  its next tool call — ahead of any verification, which could suspend
+  the turn on a permission dialog and strand the notification (SKILL.md
+  §4.5); when unsure an ARM is live, it fires regardless, since the
+  dispatcher silently no-ops an absent flag (SKILL.md §4.6).
+  Banner copy is supplied verbatim
   via the `<workflow>` and `<summary>` positional arguments — no
-  transcript scrape, no marker mechanism, no Bash-tool-result fallback.
+  transcript scrape, no marker mechanism, no Bash-tool-result
+  fallback, no fresh verification call — the summary is synthesized from
+  the completion signal already in the model's context (exit code,
+  output tail). A banner that fires beats a precise banner that never
+  fires.
 
     Banner title is `[cc-cmds] ${workflow}` and body is `${summary}`.
 

--- a/plugins/cc-cmds/skills/active-notify/SKILL.md
+++ b/plugins/cc-cmds/skills/active-notify/SKILL.md
@@ -259,12 +259,104 @@ Invoke `fire-now` at **every turn end** where:
 **Turn-end self-check**: ARM alive? user-task tool call ≥1 this turn?
 → fire-now obligation. Skipping a borderline turn is the §6.2 anti-pattern.
 
+**Background-completion exception**: when the qualifying event is a
+background task that completed — re-invoking the model, or observed
+finished mid-turn — do not wait for turn end. §4.5 requires fire-now
+as the next tool call at the moment of observation, ahead of any
+verification. The "≥1
+user-task tool call" counter above is a heuristic for in-turn work; a
+completed background task is itself a qualifying event and fires
+regardless of that counter.
+
 ### 4.4 Empty turn / AskUserQuestion-terminal turn
 
 - Pure conversational turn (no user-task tools) → no fire-now needed.
 - Turn ending with `AskUserQuestion` → harness suspends turn; no
   fire-now until the user reply turn (which will be a fresh observation
   point).
+
+### 4.5 Fire-now ordering within the turn (fire-first mandate)
+
+§4.1–§4.3 decide *whether* a fire-now is owed; this subsection
+decides *when within the turn* the owed call runs.
+
+**The moment you observe that the milestone the active ARM targets has
+completed — its exit code and output are in your context —
+`notify.sh fire-now` MUST be your next tool call, before ANY other
+tool call. This holds however you observe the completion: when it is
+already in context as the turn opens (the typical background-task
+re-invoke — see (s6)), fire-now is the first call of the turn; when a
+call you make mid-turn surfaces it — a foreground `Bash` finishing
+inline, or a `BashOutput` poll showing a background task done —
+fire-now is the first call after that observation.**
+
+Rationale: `fire-now` is auto-approved by the plugin's PreToolUse hook
+— it raises no permission dialog and always runs. Any other call
+placed first may hit a permission dialog and suspend the turn before
+fire-now is reached, stranding the notification; the user, away from
+the keyboard, then perceives an infinite hang. You cannot know which
+calls the user has allowlisted, so the rule is unconditional — not
+"before permission-gated calls" but before *any* call. fire-now is an
+instant, fire-and-forget local-disk op; ordering it first costs
+nothing.
+
+**A failed task does not change the order.** A non-zero exit sharpens
+the urge to investigate first ("let me find out why it failed") —
+that urge is the §6.2 deferred-fire anti-pattern. fire-now first, the
+failure in the copy; investigate after.
+
+Mode- and count-agnostic. The trigger is a completed, unfired
+milestone — not the mode, the fire count, or turn position. It governs
+single final fires, single intermediate fires (§4.2 count=N), and
+repeat fires alike. For repeat mode it overrides §4.3's turn-end
+timing: a background completion that re-invokes the model fires first
+on that turn (the §4.3 Background-completion exception callout), and within an
+ordinary repeat turn the turn-end fire is hoisted ahead of any closing
+verification — once the turn's work is done and only result-checking
+remains, fire before that check. §4.3's "≥1 user-task tool call"
+counter is a fallback heuristic, not a gate on this hoist — when a
+milestone is observed complete the §4.5 trigger owns the timing even
+if that counter still reads zero at the fire moment. If the completion
+maps to one of several named sub-events and you are unsure which, that
+ambiguity is
+not grounds to defer — fire on the best-fit sub-event (§6.3's
+principle — ambiguity is not an avoidance reason — governs ordering
+too).
+
+Copy is subordinate to ordering: a banner that fires beats a perfect
+banner that never fires. Build `<summary>` from the completion signal
+already in context — never from a fresh verification call — using
+`"성공"` / `"실패 (exit N)"` when the exit code is known (the norm; a
+background shell's exit code is virtually always in hand) and `"완료"`
+when there is genuinely no pass/fail signal. In single count=1 the
+first fire-now CONSUMES the flag — that banner is final, so there is
+no "fire a placeholder now, fire a corrected one after verifying."
+Verification the user's task genuinely needs happens *after* fire-now.
+
+### 4.6 Defensive fire-now (when an ARM may be live)
+
+§4.5 assumes you know a fire is owed. The harder case is not knowing.
+On a long task — exactly what this skill serves — earlier conversation
+context, including the original ARM request, may no longer be in view;
+the state flag, however, lives on disk and outlives any such loss.
+
+**When a background task completes and you cannot positively rule out
+that a notification was requested for it earlier this conversation,
+fire-now first.** The dispatcher silently no-ops when no live flag
+exists, so an unnecessary call is free; a skipped call when an ARM was
+in fact live is the bug this skill exists to prevent. Bias hard toward
+firing: a false positive is one silent no-op, a false negative is a
+stranded user. Do not Read the flag file to resolve the doubt — that
+Read is itself a permission-gated call that can suspend the turn;
+fire-now IS the probe, dispatching if a flag is live and no-opping if
+not.
+
+This does not loosen §6.1. Defensive fire-now is *firing*, not
+*arming* — it never creates a notification cycle. A banner appears only
+if a flag exists, and a flag exists only because a real ARM call ran
+this session; the flag, not your memory, is ground truth. What stays
+forbidden is unchanged: arming on self-judgment (§6.1), and calling
+fire-now when you positively know no ARM was ever placed (§6.2).
 
 ## 5. Worked examples
 
@@ -329,6 +421,39 @@ call `notify.sh arm` — invokes the inline Bash expression in §7 instead.
 User: `"역시 알림 그만"` mid-cycle → `notify.sh cancel` → flag deleted
 → any subsequent `fire-now` is silent no-op (flag absent).
 
+### (s6) Background-task completion — fire-first ordering
+
+User: `"안드로이드 빌드 백그라운드로 돌려줘, 끝나면 알림 줘"` → ARM
+single (default count=1) → model launches the build as a background
+shell → turn ends (build still running → no fire-now yet).
+
+Later: the background build completes and the harness re-invokes the
+model in a fresh turn. The completion — exit code, output tail — is
+already in context; the ARM flag is still alive (§3).
+
+1. The model's FIRST tool call is `notify.sh fire-now "build" "성공"`
+   — `<summary>` taken from the exit code already in hand, NOT from a
+   fresh log scan.
+2. ONLY THEN does the model verify results (e.g. `find ... -name
+   'logcat-*.txt' | xargs grep ...`). If that call raises a permission
+   dialog and suspends the turn, the banner has already fired — the
+   user is not stranded.
+
+**Failed-build variant**: the build exits non-zero. Same ordering —
+`notify.sh fire-now "build" "실패 (exit 1)"` first, *then* investigate.
+Diagnosing the failure before notifying is the §6.2 deferred-fire
+anti-pattern.
+
+**Mid-turn-observation variant**: rather than a re-invoke, the model
+polls a running background build with `BashOutput` mid-turn and sees
+it finished. fire-now is the first call *after* that `BashOutput` — not
+deferred to turn end.
+
+**Anti-pattern**: verification `find`/`grep` first → permission dialog
+→ turn suspends → fire-now never reached → the user, waiting on a
+banner, perceives an infinite hang. See the §6.2 deferred-fire
+anti-pattern.
+
 ## 6. Anti-patterns
 
 Do NOT call `notify.sh arm` / `fire-now` in any of these situations.
@@ -353,8 +478,14 @@ Do NOT call `notify.sh arm` / `fire-now` in any of these situations.
 
 ### 6.2 fire-now (call forbidden)
 
-- **fire-now without ARM.** Dispatcher silent no-op but it indicates
-  a model bug — fire-now must follow an ARM in the same conversation.
+- **fire-now when no ARM was ever placed.** If you positively know no
+  notification was requested this conversation, calling fire-now is a
+  model bug — the dispatcher no-ops, but the call should not exist.
+  This forbids the *known*-no-ARM call only. Not remembering an ARM is
+  uncertainty, not knowledge — it routes to §4.6 (fire), not here.
+  Defensive fire-now under genuine uncertainty whether a live ARM
+  exists is therefore correct, not forbidden — the dispatcher's
+  no-op-on-absent-flag resolves it safely.
 - **Borderline turn skip in repeat mode.** Turn had user-task tool
   calls but model "saved" the fire-now for a "more significant" turn.
   Repeat mode contract is **every** qualifying turn fires. Self-judgment
@@ -362,6 +493,16 @@ Do NOT call `notify.sh arm` / `fire-now` in any of these situations.
 - **Mid-cycle re-fire after final consume.** In `single --count=N`, the
   N+1-th fire-now is silent no-op (flag consumed). Calling it does no
   harm but indicates the model lost track of cycle state.
+- **fire-now deferred behind another tool call.** You have observed a
+  milestone under the active ARM complete, but you run a verification
+  or inspection call first — a `find`/`grep` over logs, a `Read`, an
+  `Edit`. That call can raise a permission dialog and suspend the turn
+  before fire-now runs; the banner never fires and the user, away from
+  the keyboard, perceives an infinite hang. fire-now is auto-approved
+  and never blocks — it MUST be the first tool call after you observe
+  the completion (§4.5). A failed task is the strongest form of this
+  trap: the urge to diagnose before notifying must yield — fire first,
+  investigate after.
 
 ### 6.3 Ambiguity-avoidance (inverse boundary — call forbidden)
 


### PR DESCRIPTION
## Summary

`active-notify` v1.5.0이 ARM 후 background task 완료를 처리하는 turn에서 dispatch 순서를 강제하지 않아, 모델이 결과 검증(`find`/`grep` over logs 등)을 `fire-now`보다 먼저 호출하면 사용자 allowlist에 없는 명령이 권한 다이얼로그를 띄워 turn이 정지하고 알림이 미발송되는 결함이 보고됨 (Issue #17). 사용자는 키보드 앞을 떠나 알림을 기다리던 중이라 알림도 chat 응답도 없는 무한 hang으로 인식한다.

본 PR은 SKILL.md / `_common/notify.md` 프로즈만 보강 (코드·hook·frontmatter 미수정) 하여 task 완료를 인지한 turn에서 `fire-now`를 첫 도구 호출로 의무화한다.

- **Fire-first mandate** — 활성 ARM이 대상으로 하는 milestone 완료를 관찰한 직후의 *다음* 도구 호출은 무조건 `fire-now`여야 한다. fire-now는 plugin의 PreToolUse hook이 자동 승인하므로 권한 다이얼로그를 일으키지 않는 유일한 호출이며, 모델은 사용자의 allowlist를 예측할 수 없으므로 "권한 게이트 호출보다 먼저"가 아니라 "어떤 호출보다도 먼저"여야 실행 가능한 규칙이 된다. 적용 범위: turn 시작 시점에 이미 context에 있는 background task 완료(re-invoke), foreground Bash inline 종료, BashOutput poll로 mid-turn에 드러나는 완료 모두. 실패한 task에서도 동일 순서 — 조사 욕구가 강한 함정 지점이지만 fire-now 먼저, 조사는 뒤.
- **Defensive fire-now** — long task 끝에 ARM 발화 기억이 context에서 사라졌어도 ARM이 placed되지 않았다고 확실히 배제할 수 없다면 fire-now 먼저 호출한다. flag가 ground truth이며 dispatcher는 flag 부재 시 silent no-op이라 잘못된 호출은 무해. flag 파일을 Read해서 의문을 해소하지 말 것 — 그 Read 자체가 권한 게이트 호출이라 turn을 정지시킬 수 있음.
- **Worked example + anti-pattern 정밀화** — "Background-task completion — fire-first ordering" 시나리오 추가 (failed-build / mid-turn-observation variant 포함). fire-now anti-pattern을 "fire-now without ARM"에서 "positively know no ARM was ever placed"로 재작성(uncertainty/knowledge 구분 — 전자는 defensive fire-now로 라우팅, 후자만 금지). "fire-now deferred behind another tool call" anti-pattern 신설.

## 이슈가 참조한 메커니즘 관련 노트

Issue #17 본문이 언급하는 turn-end hook fire, `milestone` ARM 파라미터, marker emit 메커니즘은 모두 v1.5.0 출시 이전 폐기된 fire-channel 초안(Issue #10)의 것이다. 출시된 v1.5.0은 hook-driven turn-end fire를 완전히 제거하고 전적으로 모델 주도 `fire-now`로 전환했으므로, 실제 수정은 v1.5.0의 모델 주도 `fire-now` 호출 *순서*를 의무화하는 형태로 이루어진다.

## prose-only 보강에 대한 솔직한 한계

hook 기반 구조적 안전망(harness-driven turn-end fire 또는 권한 다이얼로그 이벤트를 정조준한 backstop)도 검토했으나, 모든 게이팅 옵션이 소음 대 복잡도 trade-off에서 만족스럽지 않아 일단 보류했다. dogfood로 hang 재발 여부를 관찰한 뒤 hook 기반 backstop 도입 여부를 재검토한다. 환원 불가능한 잔여는 "모델이 task 완료를 처리하면서 fire-first/defensive-fire 규칙을 아예 떠올리지 않는 경우" — prose는 규칙을 명시할 수 있어도 모델이 그 규칙을 참조하도록 보장할 수 없는 갭이다.

## Release

v1.5.1 (patch — `fix(...)` 동작 하드닝). CHANGELOG entry 함께 포함.

## Test plan

- [x] `make check` (lint 5종 + readme parity) green
- [x] `git diff --exit-code README.md` exit 0 (frontmatter 미수정 → 자동 표 영향 없음)
- [x] CHANGELOG entry 추가 (`[1.5.1] - 2026-05-21`)
- [x] plugin.json version bump (1.5.0 → 1.5.1)
- [ ] macOS-CI workflow (`notify-macos.yml`) green — path filter에 `active-notify/**` + `_common/notify.md` 포함, 기존 lifecycle/pretool fixture 회귀 검증
- [ ] dogfood — long-running background task ARM → 완료 → fire-now first 동작 확인

Closes #17.