### PR TITLE
feat: claude.ai/design 핸드오프 FE 파이프라인 4스킬 + 공유 prose 2종 (v1.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-05-29
+
+claude.ai/design (Claude Design) 외부 도구를 활용한 프론트엔드 작업을 위해 4개 신규 슬래시 스킬과 공유 prose 2종을 도입한다. 기존 `design → design-review → implement → review` 파이프라인은 markdown 설계 문서 기반 백엔드 흐름에는 완벽하지만, claude.ai/design은 cc-cmds가 직접 호출할 수 없는 외부 수동 도구이고 산출물(HTML 핸드오프 번들 + `:root` CSS 토큰)을 사람이 가져와 다음 단계로 넘겨야 하기 때문에 단절이 있었다. 본 릴리스는 `design-system`(DS 워크스페이스 2-phase + 가변 Q&A 페어 사전답변 + relay 루프), `design-prompt`(base 설계 문서 stable-anchor CD 프롬프트 섹션 in-place authoring + HANDOFF CONTRACT 포함 붙여넣기 블록 emit), `design-ingest`(균일 출력 레코드 기반 단일 에이전트 리뷰 + DS 동봉/var() 두 패턴 분기 + ACCEPT/REFINE 파일 복구 루프 + ITER_CAP), `design-apply`(agent-team 적용 설계 sibling, slug 복구로 cleanup-anchor 보장) 4개 스킬과 6개 실측으로 확정된 3-rung 하이브리드 파싱 계약을 구현한 `_common/handoff-contract.md`(emitter+parser 공유 frontmatter 스키마) + `_common/parse-handoff.md`(CONTRACT/BEST-EFFORT/AGENT 직독 3-rung 추출 메커니즘)를 도입한다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Added
+
+- `plugins/cc-cmds/skills/_common/handoff-contract.md` — emitter(`design-prompt` / `design-system` phase1)와 parser(`parse-handoff.md` Rung1) 공유 frontmatter 스키마 단일 정의 (`handoff_schema: 1`). `kind`/`primary`/`pages`/`tokens_file`/`theme_mode`/`stack` 필드를 정의하고 inner README discovery 규칙 + non-load-bearing cross-check doctrine을 prose로 못 박는다.
+- `plugins/cc-cmds/skills/_common/parse-handoff.md` — 3-rung 저하(Rung1 CONTRACT / Rung2 BEST-EFFORT / Rung3 AGENT 직독) 추출 메커니즘을 정의한다. MALFORMED는 구조 게이트만(README/HTML 부재) caller-agnostic으로 한정하고, 토큰 부재는 레코드의 `tokens_absent: true`로 caller가 의미 결정한다. 출력 레코드는 happy-path와 fallback이 동형이라 호출자가 rung 분기 없이 record content로 분기한다. token value 추출은 cross-cutting이라 항상 `:root` 블록의 wrapper-inclusive raw bytes로 수집된다.
+- `plugins/cc-cmds/skills/design-system/SKILL.md` — DS 워크스페이스 2-phase 스킬. phase1은 base 설계+코드베이스에서 DS 방향성 정보를 **가변 Q&A 페어(개수·순서 가변, 고정 카테고리 enumerate 금지)**로 추출해 사전답변에 포함하고 HANDOFF CONTRACT 블록을 quote하며 relay 루프 안내를 emit한다. phase2는 incoming/ 번들을 파서로 ingest해 `tokens.css`(authored-css 블록만 + wrapper 보존 + provenance 헤더 + theme 정렬 + dedup)·`tokens.md`·`components.md`·`manifest.json`을 생성한다. `tokens_absent` 또는 divergent 동일-theme 블록은 caller-level 차단으로 escalate.
+- `plugins/cc-cmds/skills/design-prompt/SKILL.md` — base 설계 문서 `docs/{slug}.md`에 `## Claude Design 프롬프트 + 컨텍스트` 섹션을 stable anchor로 in-place authoring(append·중복 금지)하고 파생 붙여넣기 블록 `docs/{slug}-fe/cd-prompt.paste.md`를 조립한다. 붙여넣기 블록은 HANDOFF CONTRACT + `tokens.css` byte-verbatim 인용 + 기능 의도 + 산출물 가이드라인 5블록 구조다. 재실행 시 DS manifest version 비교로 drift 경고를 emit한다.
+- `plugins/cc-cmds/skills/design-ingest/SKILL.md` — 번들 파싱 + 단일 에이전트 리뷰(5축: 토큰-vs-DS / a11y 대비비 / 반응형·터치 / base 의도 충실도 / 시각 품질) + ACCEPT/REFINE 파일 복구 루프. 균일 레코드 기반 (a) DS 동봉 drift-diff / (b) `var()` 참조-only 누락 검증 두 패턴 분기를 본문 앞부분 prose로 prominent하게 기술한다. 루프 상태는 `iter-NNN/review.md`의 `## Verdict:` 첫 줄 헤더 + 디렉토리 열거로 매 호출 fresh-context 복구. `ITER_CAP=3`은 soft cap으로 4회차 진입 시 `AskUserQuestion`으로 사용자에게 계속/강제-ACCEPT/중단 분기.
+- `plugins/cc-cmds/skills/design-apply/SKILL.md` — `design-lite` 패턴 모사 agent-team sibling. 입력 경로 `docs/{slug}-fe/handoff-extract.md`에서 `{slug}`를 파싱해 팀명 `design-apply-{slug}` 조립 + cleanup 복구 키로 사용한다. `_common/agent-team-protocol.md` + `_common/team-cleanup.md` 재사용. concrete-input bootstrap이라 greenfield 인터뷰 생략, 모호점만 narrow `AskUserQuestion`으로 보강.
+
+### Changed
+
+- `scripts/lint-skill-invariants.sh` — `EXEMPT_SKILLS` 배열에 신규 4스킬(`design-system`/`design-prompt`/`design-ingest`/`design-apply`) 추가. 33-34행 주석을 현재 멤버 전부 포괄하도록 재서술 (멀티라운드 agent-team / 단일-패스 verdict-emit / 선형 authoring / IO 오케스트레이터 모두 EXEMPT인 이유 명시; 실질적으로 non-exempt는 `design-review ↔ design-review-lite` 쌍뿐).
+- `README.md` — `make readme` 자동 재생성으로 신규 4스킬의 `## Commands` 표 행과 `## Options` 섹션이 frontmatter 기반으로 추가됨. `## Prerequisites`에 `### Claude Design 핸드오프 품질 리뷰 (선택)` 서브섹션 수동 추가 — `web-design-guidelines`가 vercel-labs `agent-skills` 리포의 skills-CLI 개별 스킬(CC 마켓플레이스 플러그인 아님)이라 `plugin.json` `dependencies`로 표현이 불가능함을 명시하고 정확한 설치 명령(`npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines`)을 제공한다.
+
+### Why
+
+claude.ai/design을 활용한 FE 작업을 cc-cmds 정규 파이프라인과 끊김 없이 연결한다. 6개 실측(원본 1 + 검증 5)으로 번들이 자유 형식임을 확인한 뒤 3-rung 하이브리드 파싱 계약을 도입했다 — 옵션 D frontmatter는 작동(4/4 확인)하지만 비-load-bearing(stale-safe cross-check), SAFE 앵커는 6/6 관찰됨(outer README + "Read X in full" + `project/` + HTML ≥1), 토큰 진실값은 항상 `:root`(주로 공유 `.css`)다. 단일 관찰을 frozen 계약으로 박지 않는 doctrine은 CD 방향성 폼 사전답변에도 적용해 가변 Q&A 페어로 추출한다. `web-design-guidelines`는 skills-CLI 개별 스킬이라 hard-dependency 표현이 불가능해 graceful degradation + README 권장-설치-명령으로 처리한다 (terminal-notifier 선례와 동일 doctrine).
+
+### Post-install notes
+
+- 외부 사용자 조치 불필요. `/plugin update cc-cmds`로 자동 반영.
+- `design-ingest`는 외부 `web-design-guidelines` 스킬이 있으면 리뷰 5축 평가를 그 스킬로 보강하고, 없으면 자체 5축 기준으로 fallback한다(graceful degradation, 리뷰 중단 없음). README "Prerequisites"에 정확한 설치 명령(`npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines`)을 명시한다.
+- DS 워크스페이스는 프로젝트 전역 `docs/design-system/` 단일이며 여러 기능에서 재사용한다.
+- `design-system` phase1은 base 설계 + 코드베이스에서 방향성 정보를 가변 Q&A 페어로 추출해 사전답변에 포함하고(고정 카테고리 enumerate 금지 — CD 폼 카테고리는 시간에 따라 변할 수 있음), CD가 사전답변 밖의 추가 질문을 던지면 사용자가 cc-cmds 세션에 그대로 전달해 답안을 받는 relay 루프를 안내한다.
+- `design-ingest`는 모든 외부 라운드를 별도 호출로 처리한다(suspend-resume). 외부 단계에서 세션이 끊겨도 디스크 아티팩트(`iter-NNN/`)만으로 재개 가능.
+- 신규 FE 스킬은 hook을 동반하지 않아 macOS-CI scope 확장 트리거(active-notify `.github/workflows/notify-macos.yml`)에 해당하지 않는다.
+
 ## [1.7.0] - 2026-05-28
 
 `design` 스킬 Step 5 (Unresolved Issue Walkthrough)의 카테고리별 옵션 메뉴에 lead recommendation 메커니즘을 도입한다. 기존에는 각 미해결 이슈를 `AskUserQuestion`으로 surface할 때 카테고리별 옵션을 그대로 늘어놓아 사용자가 어느 옵션이 lead의 best-fit인지 알 수 없었고, 결정 부담만 떠안은 채 walkthrough가 "선택지를 나열하는 단계"로 퇴화했다. 본 릴리스는 `AskUserQuestion`의 네이티브 추천 contract와 design-review subfamily에 이미 정착된 한국어 `← 추천` convention을 통합하여, auto-investigation이 confident일 때만 추천 옵션을 position 1로 이동 + `← 추천` suffix 부착 + 근거를 옵션 `description`에 cite한다. 모든 카테고리(UD/UC/UA/UR)·모든 옵션(`보류`·`팀 토론 진행` 포함)이 추천 후보가 되며, UD/UA가 4-option cap을 초과하는 케이스(`K_pick ≥ 3`)는 conditional inclusion으로 branch (a) pin + worst-cascade drop / branch (b) hide + Other 채널 reachability로 분기 처리한다 (`/plugin update cc-cmds`로 자동 반영).

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Engineering workflow commands for Claude Code.
 | Command | Description | When to use |
 |---------|-------------|-------------|
 | `/cc-cmds:design` | 에이전트 팀을 활용한 기능 설계 토론 진행 | 사용자가 새 기능 설계/아키텍처 결정/다관점 검토가 필요한 설계 논의를 요청할 때 |
+| `/cc-cmds:design-apply` | Claude Design (claude.ai/design) 산출물을 타깃 코드베이스에 통합하는 구현 상세 설계를 agent team으로 작성 | design-ingest가 ACCEPT한 핸드오프 추출본을 기반으로 실제 코드베이스에 적용할 구현 상세 설계(impl-design.md)가 필요할 때 |
+| `/cc-cmds:design-ingest` | Claude Design (claude.ai/design) 핸드오프 번들을 파싱·리뷰하고 ACCEPT/REFINE 판정으로 개선 루프 진행 | claude.ai/design 에서 받은 HTML 핸드오프 번들을 검토·수용·재프롬프트할 때 (단일 호출 또는 외부 재실행 사이 반복) |
 | `/cc-cmds:design-lite` | 2인 팀을 활용한 경량 설계 토론 | 깊은 다관점 분석보다 빠른 방향 설정이 우선될 때 (sonnet 단독 합성으로 미묘한 invariant 누락 가능) |
+| `/cc-cmds:design-prompt` | Claude Design (claude.ai/design) 실행용 프롬프트+컨텍스트를 base 설계 문서에 authoring하고 붙여넣기 블록 emit (standalone + idempotent, HANDOFF CONTRACT 포함) | base 설계 작성 후, claude.ai/design 에 보낼 의도 중심 프롬프트와 DS 참조를 base 설계 문서에 추가하거나 리뷰 반영본으로 붙여넣기 블록을 재조립할 때 |
 | `/cc-cmds:design-review` | 설계 문서 최종 리뷰 | 작성된 설계 문서를 다중 반복 에이전트 리뷰(외부/내부 사이클)로 최종 검증·수렴시키고자 할 때 |
 | `/cc-cmds:design-review-lite` | 설계 문서 경량 사이클 리뷰 | 설계 문서를 간결한 반복 사이클로 빠르게 검증하고 싶을 때 (미묘한 termination invariant·동시성 검출률 약화 가능) |
+| `/cc-cmds:design-system` | Claude Design (claude.ai/design) DS 생성 프롬프트 emit + DS 번들 ingest로 docs/design-system/ 워크스페이스 구축 (2-phase) | FE 파이프라인 시작 전 프로젝트 전역 design system을 claude.ai/design으로 생성·도입할 때 (1회성 또는 재ingest) |
 | `/cc-cmds:design-upgrade` | 팀원 모델 업그레이드 분석 | design 스킬의 팀 구성 제안에서 haiku/sonnet으로 배정된 팀원 중 opus로 승격이 유의미한 역할이 있는지 검토할 때 |
 | `/cc-cmds:implement` | 설계 문서 기반 구현 | 사용자가 작성된 설계 문서를 바탕으로 단계적 계획을 세우고 실제 구현을 수행하기를 원할 때 |
 | `/cc-cmds:review` | 에이전트 팀을 활용한 다관점 코드 리뷰 | 사용자가 PR/로컬 diff/파일 경로에 대한 다관점 코드 리뷰(보안/성능/품질 등)를 요청할 때 |
@@ -64,6 +68,16 @@ brew install jq   # PreToolUse hook 의존성
 
 terminal-notifier가 없거나 macOS가 아니면 알림은 오류 없이 비활성화됩니다.
 
+### Claude Design 핸드오프 품질 리뷰 (선택)
+
+`/cc-cmds:design-ingest`의 단일 에이전트 리뷰 단계는 환경에 `web-design-guidelines` 스킬이 설치되어 있으면 UI/접근성/반응형 평가를 그 스킬로 보강합니다. 이 스킬은 vercel-labs `agent-skills` 리포의 **skills-CLI 개별 스킬**이며 Claude Code 마켓플레이스 플러그인이 아닙니다 — 따라서 cc-cmds `plugin.json`의 `dependencies`로는 표현이 불가능하고, 다음 명령으로 `~/.claude/skills/`에 직접 설치합니다.
+
+```bash
+npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines
+```
+
+부재 시 design-ingest는 자체 5축 기준(토큰-vs-DS 일치도, a11y 대비비 산술, 반응형/터치 영역 44px+, base 의도 충실도, 시각 품질)으로 fallback하며 리뷰는 중단되지 않습니다. terminal-notifier와 동일 doctrine — `plugin.json` `dependencies`로 표현 불가한 선택적 외부 의존성(skills-CLI 개별 스킬·brew 도구 등)은 graceful degradation + README 권장-설치-명령 패턴을 따릅니다.
+
 ## Install
 
 ```bash
@@ -106,9 +120,13 @@ terminal-notifier가 없거나 macOS가 아니면 알림은 오류 없이 비활
 <!-- SKILLS_OPTIONS_START -->
 
 - [/cc-cmds:design](#cc-cmdsdesign)
+- [/cc-cmds:design-apply](#cc-cmdsdesign-apply)
+- [/cc-cmds:design-ingest](#cc-cmdsdesign-ingest)
 - [/cc-cmds:design-lite](#cc-cmdsdesign-lite)
+- [/cc-cmds:design-prompt](#cc-cmdsdesign-prompt)
 - [/cc-cmds:design-review](#cc-cmdsdesign-review)
 - [/cc-cmds:design-review-lite](#cc-cmdsdesign-review-lite)
+- [/cc-cmds:design-system](#cc-cmdsdesign-system)
 - [/cc-cmds:design-upgrade](#cc-cmdsdesign-upgrade)
 - [/cc-cmds:implement](#cc-cmdsimplement)
 - [/cc-cmds:review](#cc-cmdsreview)
@@ -122,6 +140,22 @@ terminal-notifier가 없거나 macOS가 아니면 알림은 오류 없이 비활
 | --- | --- | --- |
 | `<task>` | (required) | 설계 토론을 진행할 작업 주제 (자유형 한국어/영문 텍스트). |
 
+### /cc-cmds:design-apply
+
+**Usage**: `/cc-cmds:design-apply <handoff-extract-path>`
+
+| Option | Default | Summary |
+| --- | --- | --- |
+| `<handoff-extract-path>` | (required) | design-ingest가 확정한 안정 사본 (`docs/{slug}-fe/handoff-extract.md`); 본 스킬이 slug 파싱·팀명 조립·cleanup 복구의 단일 앵커 |
+
+### /cc-cmds:design-ingest
+
+**Usage**: `/cc-cmds:design-ingest <handoff-dir-path>`
+
+| Option | Default | Summary |
+| --- | --- | --- |
+| `<handoff-dir-path>` | (required) | 기능 핸드오프 디렉토리 (`docs/{slug}-fe/handoff`); incoming/ 하위 번들을 소비 |
+
 ### /cc-cmds:design-lite
 
 **Usage**: `/cc-cmds:design-lite <task>`
@@ -129,6 +163,14 @@ terminal-notifier가 없거나 macOS가 아니면 알림은 오류 없이 비활
 | Option | Default | Summary |
 | --- | --- | --- |
 | `<task>` | (required) | 설계 토론을 진행할 작업 주제 (자유형 한국어/영문 텍스트). |
+
+### /cc-cmds:design-prompt
+
+**Usage**: `/cc-cmds:design-prompt <base-doc-path>`
+
+| Option | Default | Summary |
+| --- | --- | --- |
+| `<base-doc-path>` | (required) | base 설계 문서 경로 (`docs/{slug}.md`); 본 스킬이 그 안에 CD 프롬프트 섹션을 in-place authoring |
 
 ### /cc-cmds:design-review
 
@@ -159,6 +201,14 @@ terminal-notifier가 없거나 macOS가 아니면 알림은 오류 없이 비활
 | --- | --- | --- |
 | `<design-doc-path>` | (required) | 리뷰 대상 설계 문서 경로 (`.md`) |
 | `--base` | off | 기존 내용 일관성만 검증; 신규 구현 세부 제안 금지 (BASE MODE CONSTRAINT) |
+
+### /cc-cmds:design-system
+
+**Usage**: `/cc-cmds:design-system [<intent>]`
+
+| Option | Default | Summary |
+| --- | --- | --- |
+| `[<intent>]` | _(optional)_ | DS 생성 의도/스코프 서술용 자유형 토큰 (생략 시 base 설계·코드베이스에서 추론) |
 
 ### /cc-cmds:design-upgrade
 

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/_common/handoff-contract.md
+++ b/plugins/cc-cmds/skills/_common/handoff-contract.md
@@ -1,0 +1,78 @@
+# Claude Design Handoff Frontmatter Contract (Shared Schema)
+
+Single source of truth for the YAML frontmatter we ask Claude Design (claude.ai/design) to embed in handoff bundles. Both the **emitters** (`design-system` phase 1 and `design-prompt`) and the **parser** (`_common/parse-handoff.md` Rung 1) cite this file:
+
+- Emitters quote the schema block below verbatim inside a "HANDOFF CONTRACT" section of the prompt they send to Claude Design.
+- The parser uses the same schema as its Rung 1 fast-path source of bundle structure metadata.
+
+Keeping both sides citing one file means schema drift fixes happen in one place.
+
+## Purpose and posture
+
+We do not control the Claude Design output format — the 6-bundle field study (`docs/fe-claude-design-pipeline.md` §0.1) confirmed it is a free-form artifact behind a thin set of stable anchors (outer README, `project/` folder, ≥1 HTML, `:root` for tokens). To make parsing predictable on the common path, we ask Claude Design to **prepend a YAML frontmatter to the inner README** describing the bundle structure we just received. This is an opportunistic accelerator, not a load-bearing contract: the parser degrades gracefully through Rung 2 (SAFE anchors) and Rung 3 (agent-direct-read) when frontmatter is absent, malformed, or stale.
+
+Three properties follow from that posture:
+
+1. **Stale-safe.** Every field is cross-checked against the underlying source artifacts. If `primary` names a file that does not exist, the parser drops that field to Rung 2; it does not silently trust the declaration.
+2. **Structure-only.** The contract describes **where to look** (paths, page list, token source file). It never carries token *values* — those are always read from the actual `:root` blocks on disk, regardless of which rung fired.
+3. **Versioned by integer.** A strict-equality `handoff_schema` integer lets the parser detect skew. Any mismatch degrades to Rung 2 rather than silently partially trusting an unknown schema.
+
+## Schema (`handoff_schema: 1`)
+
+The exact block the emitter pastes into the "HANDOFF CONTRACT" section:
+
+```yaml
+---
+handoff_schema: 1                       # int (strict-equality version key; skew → degrade to Rung 2)
+kind: feature                           # feature | design-system (caller bundle-kind assertion)
+feature: profile-settings               # kebab slug (need not match project folder name)
+fidelity: high                          # high | mid | low
+primary: "Profile Settings.html"        # bundle-root relative path to the primary page
+pages:                                  # every HTML page the bundle ships, in display order
+    - { file: "Profile Settings.html", title: "Profile Settings", route: "/" }
+tokens_file: "colors_and_type.css"      # :root truth-source path (often shared .css; may be the primary HTML for inline-only)
+theme_mode: ["light", "dark"]           # ["light"] for non-themed bundles
+stack: react                            # opportunistic: react | web-components | pure-html (HTML detection is authoritative)
+components: ["Button", "Toggle"]        # opportunistic hint list
+notes: ""                               # free-form caveats / TODOs from CD; informational
+---
+```
+
+## Field semantics
+
+- **`handoff_schema`** — Integer, strict equality with the parser's expected version. The parser refuses to interpret any other value and falls back to Rung 2 for every field. There is no "partial trust" of an unknown schema.
+- **`kind`** — Bundle classification. Each caller asserts the expected kind:
+    - `design-system` phase 2 expects `kind: design-system`.
+    - `design-ingest` expects `kind: feature`.
+    Mismatch is a **caller-level warning**, not a parser MALFORMED — callers may choose to proceed (e.g., the user intentionally ingests a page bundle as DS source).
+- **`feature`** — Kebab-case slug identifying the feature the bundle implements. Need not equal the project folder name (Claude Design's `<project-name>/` slug varies independently). Informational; not used for path resolution.
+- **`fidelity`** — `high` | `mid` | `low`. Self-declared by Claude Design. Informational only; the reviewing Agent in `design-ingest` may compare against the requested fidelity but the parser does not act on it.
+- **`primary`** — Bundle-root relative path to the page the coding agent should treat as the canonical entry point. **Cross-checked**: if the file does not exist, the parser drops `primary` to Rung 2 (outer README "Read `<path>` in full" pattern → single-HTML fallback → AskUserQuestion).
+- **`pages[]`** — Every HTML page in the bundle, in display order. Each entry: `file` (bundle-root relative path), `title` (display label), `route` (intended path in the rendered app, useful for routing decisions in `design-apply`). **Cross-checked**: each `file` must exist; missing entries drop to Rung 2 per-entry.
+- **`tokens_file`** — Path to the file that holds the authoritative `:root` block(s). Observed in the 6-bundle study to land most often in a shared `.css` (e.g., `colors_and_type.css`, `tokens.css`, `styles.css`), occasionally in the primary HTML's inline `<style>`. **Structure short-circuit only — this field never supplies token values.** Values are always read from the actual `:root` blocks at parse time. Cross-checked: file must exist and contain at least one `:root` selector; otherwise drop to Rung 2 for tokens.
+- **`theme_mode[]`** — Declared theme variants. `["light"]` for non-themed bundles; `["light", "dark"]` (or more) when the bundle ships a themed token set. Used by the parser to anticipate wrapper selectors (`[data-theme="dark"]`, `@media (prefers-color-scheme: dark)`, `.dark`) when scanning `:root` blocks.
+- **`stack`** — `react` | `web-components` | `pure-html`. **Opportunistic hint only.** Stack detection from the HTML body is authoritative — the parser greps for the React 18 CDN signature first, then `customElements.define`, then defaults to `pure-html`. If `stack` disagrees with the HTML, the HTML wins and the hint is logged as a warning.
+- **`components[]`** — Opportunistic name hints for the component inventory. The parser builds its component records by scanning the HTML/JSX directly; this list is used as a hint to disambiguate or label inferred components but never as the source of truth.
+- **`notes`** — Free-form caveats from Claude Design (TODOs, known gaps, fidelity notes). Informational; the reviewing Agent in `design-ingest` may surface this verbatim in `handoff-extract.md`.
+
+## Where the frontmatter lands (observed)
+
+In the 6-bundle field study, Claude Design places the contract frontmatter in the **inner README** — the `README.md` co-located with the HTML files inside the content folder — and leaves the **outer README** (the one starting with "CODING AGENTS: READ THIS FIRST") untouched as a human-facing document.
+
+Practical consequences for the parser:
+
+- Do **not** assume a fixed path. Discover the inner README by walking every `README.md` under `{bundle-root}` and selecting the one whose first ~50 lines contain `handoff_schema:`.
+- The outer "CODING AGENTS" README is still a valuable Rung 2 anchor (it carries the ``Read `<path>` in full`` primary-page marker that worked in 6/6 observed bundles), but it is not the contract source. Both READMEs coexist; the parser treats them as separate inputs.
+
+## Non-load-bearing contract
+
+The parser must not silently trust frontmatter values that disagree with the on-disk artifacts. The discipline is:
+
+- **Validate every field against the source** before consuming it (see Rung 1 cross-check rules in `parse-handoff.md`).
+- **Degrade per-field**, not per-document. A bundle whose `primary` is stale but whose `pages[]` is intact uses Rung 1 for `pages[]` and Rung 2 for `primary`.
+- **Never derive token values from the contract.** `tokens_file` is a path hint; the actual `--token: value;` declarations come from reading that file's `:root` blocks at parse time, with `provenance: authored-css` only when the bytes are present on disk.
+- **Surface mismatches** as `unresolved_questions[]` entries in the parser's output record so the calling skill (or its reviewing Agent) can react.
+
+## File format note
+
+This file is markdown prose with one embedded YAML schema block. It is loaded via `Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md` by every emitter and by the parser. It contains no bash, no path resolution, and no executable instructions — its only job is to be the single canonical schema definition that all sides cite.

--- a/plugins/cc-cmds/skills/_common/parse-handoff.md
+++ b/plugins/cc-cmds/skills/_common/parse-handoff.md
@@ -1,0 +1,289 @@
+# Claude Design Handoff Bundle Parser (Shared Extraction Contract)
+
+Shared parsing prose for claude.ai/design handoff bundles. Loaded by both ingest callers:
+
+- `design-system` phase 2 (DS bundle → `tokens.css` / `tokens.md` / `components.md` / `manifest.json`).
+- `design-ingest` (feature bundle → `iter-NNN/handoff-extract.md` + reviewing Agent).
+
+Both callers receive the **same uniform output record** regardless of which extraction rung fired. Callers branch on record content (e.g., `tokens_absent`, `unresolved_questions`), never on "which rung succeeded." The rung ladder is an internal implementation detail of this file.
+
+The companion file `_common/handoff-contract.md` defines the YAML frontmatter schema this parser fast-paths on Rung 1; emitters cite the same file. Load both:
+
+```
+Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md
+Read ${CLAUDE_SKILL_DIR}/../_common/parse-handoff.md
+```
+
+## 1. Input
+
+A single directory path `{bundle-root}`. The caller selects this root from its drop directory (typically the most-recently-modified sub-directory under `docs/design-system/incoming/` or `docs/{slug}-fe/handoff/incoming/`) before invoking the contract. This file does not own multi-bundle disambiguation.
+
+## 2. MALFORMED structure gate (pre-ladder, caller-agnostic)
+
+Before entering the rung ladder, check the three structural preconditions. If ANY fails, return immediately:
+
+```
+{ status: "MALFORMED", reason: <one of below> }
+```
+
+Failure conditions:
+
+- `{bundle-root}` is not a directory, or is not readable.
+- `find {bundle-root} -name 'README.md'` yields zero results (neither outer nor inner README present).
+- `find {bundle-root} -name '*.html'` yields zero results (no HTML pages at all).
+
+**Token absence is NOT a MALFORMED condition.** A bundle with a README and at least one HTML but no `:root` block proceeds through the ladder; the resulting record carries `tokens_absent: true` and the caller decides severity. (`design-system` phase 2 treats it as a blocker; `design-ingest` routes to the `var()`-reference verification path.)
+
+The gate is intentionally narrow. Anything richer (token presence, primary-page resolution, contract validity) lives inside the ladder and surfaces as record content, not as MALFORMED.
+
+## 3. README discovery
+
+```
+find {bundle-root} -name 'README.md'
+```
+
+For each result, scan the first ~50 lines for the literal key `handoff_schema:`.
+
+- The README whose first ~50 lines contain `handoff_schema:` is the **inner README** — the Rung 1 fast-path source.
+- All other READMEs are **outer-README candidates** — Rung 2 anchors for primary-page resolution via the ``Read `<path>` in full`` pattern.
+- If no README matches, `inner_readme = null` and the ladder skips directly to Rung 2 for every field.
+- If multiple READMEs match (unobserved in the field study, but defensible), prefer the one nested deepest under `project/` or its equivalent content folder.
+
+## 4. Rung 1 — CONTRACT (frontmatter short-circuit)
+
+**Condition:** `inner_readme` is non-null AND its `handoff_schema` equals `1`.
+
+Parse the YAML frontmatter (everything between the first `---` and the next `---` in `inner_readme`) and extract `kind`, `primary`, `pages[]`, `tokens_file`, `theme_mode[]`, `stack`, `components[]`, plus `feature`, `fidelity`, `notes` (informational).
+
+Then **cross-check every field against on-disk artifacts** before consuming it. Mismatched fields drop to Rung 2 *per field* — Rung 1 success or failure is not all-or-nothing:
+
+| Field | Cross-check | On mismatch |
+|-------|-------------|-------------|
+| `primary` | File exists at `{bundle-root}/{primary}` | drop to Rung 2 for `primary`; add `unresolved_questions: "Rung1 primary='<value>' missing on disk"` |
+| `tokens_file` | File exists AND contains at least one `:root` selector | drop to Rung 2 for tokens source; add unresolved |
+| `pages[i].file` | File exists at `{bundle-root}/{file}` | drop that entry to Rung 2; keep valid entries |
+| `stack` | HTML body matches the declared stack (see Rung 2 stack-detection grep) | HTML wins; log warning; do NOT mark unresolved (this is a hint, not a load-bearing field) |
+| `kind` | Caller bundle-kind expectation | parser does NOT block; tag record `kind_mismatch: true` so caller can warn |
+| `theme_mode`, `components`, `feature`, `fidelity`, `notes` | No automated cross-check (these are descriptors, not load-bearing) | passed through as-is |
+
+Fields that pass cross-check are consumed at Rung 1. Fields that fail re-enter the ladder at Rung 2.
+
+Set `contract_used: true` and `rungs_fired_per_field.<name> = 1` for each Rung 1 success.
+
+## 5. Rung 2 — BEST-EFFORT (SAFE anchor heuristics)
+
+**Condition:** Rung 1 did not fire (no valid contract) OR specific Rung 1 fields failed cross-check.
+
+For each field that still needs resolution, apply the heuristic below. The anchors come from the 6-bundle field study and are observed in 6/6 bundles unless noted.
+
+### 5.1 Primary page
+
+1. Scan **every** outer-README candidate for the literal pattern ``Read `<path>` in full`` (case-insensitive on `Read` / `in full`; the backtick-quoted `<path>` is the canonical match). Take the first match across READMEs. (Pattern observed in 6/6.)
+2. If no match: list all `*.html` under `{bundle-root}`. If exactly one HTML, that is `primary`.
+3. If multiple HTML files and no README marker: add `unresolved_questions: "PRIMARY_AMBIGUOUS: candidates=[file1, file2, ...]"`. The caller surfaces this via `AskUserQuestion`. The parser does not pick blindly.
+
+### 5.2 Pages
+
+`find {bundle-root} -name '*.html'` and emit each as a `pages[]` entry:
+
+```
+{ file: <relative-path>, title: <stem with hyphens→spaces, Title Case>, route: null, provenance: "rung2" }
+```
+
+Tag the `primary` entry with `is_primary: true`. The `title` heuristic is intentionally lossy — `design-apply` can refine route/title when the contract was absent.
+
+### 5.3 Tokens source
+
+Search for `:root` blocks in priority order:
+
+1. If Rung 1 surfaced a valid `tokens_file`, use that file.
+2. Walk `<link rel="stylesheet" href="...">` tags in every HTML file and follow each `href` to its `.css` file under `{bundle-root}`. Any `.css` file containing `:root` is a token-source candidate.
+3. Scan the primary HTML's inline `<style>` blocks for `:root`.
+
+All candidates are extracted in §7 (cross-cutting token value extraction); Rung 2 only locates the files.
+
+### 5.4 Stack detection (HTML is authoritative)
+
+Grep across HTML files in priority order:
+
+- Match `react@18` OR `react-dom@18` OR `@babel/standalone` → `stack: "react"`.
+- Else match `customElements.define\(` → `stack: "web-components"`.
+- Else → `stack: "pure-html"`.
+
+This grep is also used in Rung 1 to validate a Rung 1 `stack` hint.
+
+### 5.5 Theme modes
+
+Scan all `:root` selectors and their wrapper contexts across token-source files. Detect:
+
+- `:root[data-theme="<name>"]` → theme `<name>`.
+- `@media (prefers-color-scheme: dark) { :root { ... } }` → theme `dark`.
+- `.dark :root` or `.dark { ... }` (when used as a theme switch) → theme `dark`.
+- Plain `:root` with no wrapper → theme `default` (treated as `light` for catalog purposes).
+
+`theme_modes[]` is the deduplicated list of detected themes. Single-theme bundles emit `["light"]`.
+
+### 5.6 Component inventory (intentionally loose)
+
+Component records are coarser than token blocks — they capture **shape**, not values, and are explicitly tagged with `provenance: "rung2"` (or `"agent-inferred"` from Rung 3) so callers know not to derive contracts from them. Scan rules by stack:
+
+- **React** (`stack == "react"`):
+    - Match `function ([A-Z][A-Za-z0-9_]*)\s*\(` and `const ([A-Z][A-Za-z0-9_]*)\s*=\s*\(` in JSX/HTML files.
+    - Source file = the file containing the declaration.
+- **Web Components** (`stack == "web-components"`):
+    - Match `customElements\.define\(\s*["']([a-z][a-z0-9-]+)["']`.
+    - Source file = the file containing the registration.
+- **pure-HTML** (`stack == "pure-html"`):
+    - Collect every `className=` / `class=` attribute. Cluster classes appearing in 3+ distinct elements. Each cluster is a component candidate named after its most-distinctive class (e.g., `card-header` over `card`).
+
+Each component record:
+
+```
+{
+  name: <string>,
+  stack_kind: <react | web-components | pure-html>,
+  anatomy: <terse prose or empty>,
+  states: [<hover|focus|disabled|...>],
+  a11y: [<aria-* attributes observed>],
+  usage: <terse prose or empty>,
+  source_file: <relative path>,
+  provenance: "rung2"
+}
+```
+
+`anatomy` / `usage` may be empty strings on Rung 2 — the reviewing Agent in `design-ingest` fills them via Rung 3 when the field study's looseness leaves the record under-specified. **Do not retrofit token-level rigor** (verbatim slice, divergence grouping) to components; the field study confirmed components are inferential prose, not byte-anchored bytes.
+
+## 6. Rung 3 — AGENT direct-read (terminal fallback)
+
+**Condition:** Rung 2 anchors were indecisive (multiple primary candidates, ambiguous token source, component inventory too sparse to be useful), AND the resulting record's `unresolved_questions[]` is large enough that callers cannot proceed productively.
+
+Spawn an `Agent()` (this parser's calling skill is responsible for the call) with the bundle's primary HTML and any imported files as input, and ask it to extract `primary`, `pages[]`, `components[]`, and structural prose. Tag every Rung 3 output with `provenance: "agent-inferred"`.
+
+**Hard constraint — Rung 3 cannot generate token values.** Token *values* always come from §7 (reading `:root` bytes). Rung 3 may correct a Rung 2 token-source *location* (e.g., "the canonical token file is `theme/colors.css`, not the inline `<style>`"), but the actual bytes still flow through `provenance: "authored-css"`. This keeps `design-system` phase 2's `tokens.css` synthesis byte-verbatim.
+
+Note: this Agent is a **structural-extraction Agent**, distinct from `design-ingest`'s separate **quality-review Agent** (the 5-axis review described in `design-ingest/SKILL.md`). The two run at different lifecycle points with different inputs.
+
+## 7. Token value extraction (cross-cutting; runs regardless of rung)
+
+Token values are always read from actual `:root` blocks on disk. This step runs once the token-source files have been located (by Rung 1 contract, Rung 2 heuristic, or Rung 3 correction).
+
+For each candidate file:
+
+1. Find every CSS selector matching `:root`, `:root[<attribute>]`, `.dark :root`, or `:root` nested inside `@media (prefers-color-scheme: ...) { ... }` or `@media (...) { ... }`.
+2. For each match, capture the **wrapper-inclusive raw block text** — for example, the full `@media (prefers-color-scheme: dark) { :root { --bg: #111; --fg: #eee; } }` block, not just the inner `:root { ... }` portion. Stripping wrappers would make dark tokens apply unconditionally when the block is re-emitted.
+3. Determine `theme_key`:
+    - Bare `:root` → `default`.
+    - `:root[data-theme="dark"]` → `dark` (and so on for other values).
+    - `@media (prefers-color-scheme: dark)` wrapper → `dark`.
+    - `.dark` switch → `dark`.
+4. Record `provenance: "authored-css"`; record `origin: "inline-style"` if the source file is an HTML file's inline `<style>`, else `origin: "shared-file"`.
+5. Emit a `token_blocks[]` entry:
+    ```
+    {
+      source_file: <relative path>,
+      selector: <e.g., ":root[data-theme=\"dark\"]">,
+      theme_key: <default | dark | light | ...>,
+      raw_block_text: <wrapper-inclusive verbatim bytes>,
+      provenance: "authored-css",
+      origin: "inline-style" | "shared-file",
+      divergent: false
+    }
+    ```
+6. After collecting all blocks, **derive `token_groups`** by grouping `token_blocks[]` on `(selector, theme_key)`:
+    - If a group's blocks have identical `raw_block_text`, dedupe to a single entry (the parser caller may emit "N sources identical" as a comment).
+    - If a group's blocks differ in `raw_block_text` (same `:root[data-theme="dark"]` but different declarations across files), set `divergent: true` on every member block and add `unresolved_questions: "DIVERGENT_TOKENS: theme=<theme_key>, sources=[file1, file2]"`. Do NOT auto-collapse — divergence is meaningful (see caller branching below).
+7. **Token values are never normalized.** Preserve `oklch(0.7 0.2 240)` vs `#3b82f6` vs `rgb(59 130 246)` exactly as written. Any color-space conversion happens later in `design-apply`, not in the parser.
+
+Finally, scan every HTML/JSX file under `{bundle-root}` for `var(--<name>)` references. Any `--<name>` that appears in a `var()` call but is not declared in any `:root` block goes into `referenced_undefined_vars[]`. `design-ingest` uses this list to verify against the canonical DS for `var()`-only feature bundles.
+
+If `token_blocks[]` is empty after this step, set `tokens_absent: true`.
+
+## 8. Uniform output record
+
+Both callers receive the same shape. Happy-path and fallback differ only in `provenance` tags, `rungs_fired_per_field`, and `unresolved_questions[]` content — never in record structure.
+
+```
+{
+  status: "OK" | "MALFORMED",
+  reason: <string when MALFORMED>,
+
+  // Structural metadata
+  primary: <bundle-root relative path | null>,
+  pages: [ { file, title, route?, provenance, is_primary?: bool } ],
+  stack: "react" | "web-components" | "pure-html",
+  theme_modes: [ "light", "dark", ... ],
+
+  // Tokens — values always from on-disk :root bytes
+  token_blocks: [
+    { source_file, selector, theme_key, raw_block_text, provenance, origin?, divergent }
+  ],
+  token_groups: [
+    { selector, theme_key, blocks: [ /* indices into token_blocks */ ], divergent }
+  ],
+  tokens_absent: <bool>,                        // true iff token_blocks is empty
+  referenced_undefined_vars: [ "--token-name", ... ],
+
+  // Components — lossy by design
+  components: [
+    { name, stack_kind, anatomy, states, a11y, usage, source_file, provenance }
+  ],
+
+  // Contract metadata
+  kind: "feature" | "design-system" | null,     // from Rung 1 contract; null if no contract
+  kind_mismatch: <bool>,                        // caller assertion failure flag
+  feature: <slug | null>,                       // from Rung 1
+  fidelity: "high" | "mid" | "low" | null,      // from Rung 1
+  notes: <string>,                              // from Rung 1
+
+  // Telemetry for caller branching
+  contract_used: <bool>,                        // true iff Rung 1 fired for at least one field
+  rungs_fired_per_field: {                      // tracks which rung produced each field
+    primary: 1 | 2 | 3,
+    pages: 1 | 2 | 3,
+    tokens: 1 | 2 | 3,
+    stack: 1 | 2,
+    theme_modes: 1 | 2,
+    components: 2 | 3
+  },
+  unresolved_questions: [ <human-readable string>, ... ]
+}
+```
+
+### Caller branching examples (informational)
+
+- `status == "MALFORMED"` → caller surfaces via `AskUserQuestion` (edit-bundle-and-retry / re-download / abort).
+- `kind_mismatch == true` → caller emits a warning prose but typically proceeds.
+- `tokens_absent == true`:
+    - `design-system` phase 2: **block** — DS workspace cannot be built without `:root` bytes; escalate to user.
+    - `design-ingest`: this is the `var()`-only feature-bundle path; verify each `referenced_undefined_vars[]` entry against the canonical `docs/design-system/tokens.css`; any miss = REFINE.
+- Any `token_groups[i].divergent == true`:
+    - `design-system` phase 2: escalate — the DS must be uniform.
+    - `design-ingest`: pass to the reviewing Agent as REFINE-eligible (the divergence may be intentional per-screen, not a hard block).
+- `unresolved_questions[]` non-empty → caller decides per-question (some surface via `AskUserQuestion`, some go into `handoff-extract.md` as open notes for the reviewing Agent).
+
+## 9. Idempotency
+
+The bundle is immutable input. Re-invoking the parser on the same `{bundle-root}` MUST yield an identical record (same field values, same `rungs_fired_per_field`, same `unresolved_questions[]` ordering). Callers may rely on this for retry-on-error or restart-after-interruption.
+
+## 10. Bash portability note
+
+This file is markdown prose, and the repo's `lint-bash-portability.sh` scans only `*.sh` files. Bash idioms embedded here are therefore **manually disciplined** for BSD (macOS) ↔ GNU (Linux) coreutils compatibility. Calling skills should mirror these conventions when shelling out:
+
+- `find "$dir" -mindepth 1 -maxdepth 1 -type d` — portable directory enumeration.
+- `find "$dir" -maxdepth 1 -type f -name '*.html'` — portable file glob with single-quoted pattern.
+- `mv -n` — portable atomic non-overwrite move.
+- Avoid GNU-only `find -printf`, GNU-only `sed -i` without backup arg, BSD-only `readlink -f` without `-e`.
+
+## 11. Calling convention recap
+
+The calling SKILL.md performs all write/output operations inline; this prose owns extraction only. The minimal call pattern in a caller skill is:
+
+```
+Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md
+Read ${CLAUDE_SKILL_DIR}/../_common/parse-handoff.md
+# ... apply MALFORMED gate, ladder, token extraction ...
+# ... emit uniform record ...
+# Caller now branches on record content, NOT on which rung fired.
+```
+
+The handoff-contract is loaded first so emitter and parser both quote the same schema definition; the parse-handoff prose builds on that schema for Rung 1.

--- a/plugins/cc-cmds/skills/design-apply/SKILL.md
+++ b/plugins/cc-cmds/skills/design-apply/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: design-apply
+description: Claude Design (claude.ai/design) 산출물을 타깃 코드베이스에 통합하는 구현 상세 설계를 agent team으로 작성
+when_to_use: design-ingest가 ACCEPT한 핸드오프 추출본을 기반으로 실제 코드베이스에 적용할 구현 상세 설계(impl-design.md)가 필요할 때
+disable-model-invocation: true
+usage: "/cc-cmds:design-apply <handoff-extract-path>"
+options:
+    - name: "<handoff-extract-path>"
+      kind: positional
+      required: true
+      summary: "design-ingest가 확정한 안정 사본 (`docs/{slug}-fe/handoff-extract.md`); 본 스킬이 slug 파싱·팀명 조립·cleanup 복구의 단일 앵커"
+---
+
+Author the implementation-detail design document `docs/{slug}-fe/impl-design.md` that bridges Claude Design's HTML prototype to actual code in the target stack. This is a **lightweight sibling of `/cc-cmds:design`** — it reuses the same agent-team protocol (`_common/agent-team-protocol.md`) and cleanup machinery (`_common/team-cleanup.md`) but skips the Step 1 greenfield interview because its inputs are concrete (the design-ingest extract + base design document + DS workspace + codebase).
+
+The decisions in scope are component mapping (HTML prototype → codebase components), state management, routing, file layout, token/component usage rules (DS-copy vs `var()`-reference based on the pattern design-ingest detected), and test strategy. These are design judgments the downstream `/cc-cmds:implement` would refuse to make ("don't deviate from the design document") — so they belong here, in a markdown design output that `/cc-cmds:design-review` can then audit.
+
+All team discussion and inter-agent communication is in English to optimize token usage. User-facing communication (proposal, presentation) and the saved `impl-design.md` are in Korean.
+
+## Input parsing and slug recovery
+
+- Extract `{slug}` from `<handoff-extract-path>`. The path must match `docs/{slug}-fe/handoff-extract.md` exactly. On any other shape emit Korean error: *"입력 경로는 `docs/<slug>-fe/handoff-extract.md` 형식이어야 합니다."* and end.
+- The `{slug}` is the recovery anchor for two purposes:
+    - **Team naming**: the agent team is created as `design-apply-{slug}` (e.g., `design-apply-profile-settings`). This name is reconstructable from the input path on every invocation without any in-session memory — required by `_common/team-cleanup.md`'s lead-memory-free cleanup contract.
+    - **Output path**: `docs/{slug}-fe/impl-design.md` (fixed name; cleanup recovery uses the input-path slug, not this output, since the output may not exist yet on first invocation).
+
+## Step 1: Concrete-input context gathering (Korean)
+
+Unlike `/cc-cmds:design`, **do NOT run a greenfield requirements interview**. The inputs are concrete:
+
+- Read `<handoff-extract-path>` (the design-ingest stable extract).
+- Read `docs/{slug}.md` (the base design document — both the original base sections and the "Claude Design 프롬프트 + 컨텍스트" section authored by `/cc-cmds:design-prompt`).
+- Read `docs/design-system/{tokens.md, components.md, manifest.json}` (DS reference). Token semantics, component contracts, current DS version.
+- Read the archived bundle at `docs/{slug}-fe/handoff/iter-<latest>/bundle/` if needed for primary HTML + component JSX details — the parser-extracted summary is in `handoff-extract.md`, but the bundle is authoritative for visual/structural fidelity questions.
+- Explore the target codebase with `find` / `grep` (and Read) to identify existing component patterns, stack (React/Vue/web-components/etc.), routing approach, state management, file layout conventions, and test setup. Use Claude Context MCP for broad searches if the codebase is indexed; otherwise raw grep/find.
+
+If ambiguous points remain after this concrete-input gathering, use `AskUserQuestion` for **narrow, targeted interviews** — one or two questions per topic only. Do not enumerate categories or open the interview wide. The discriminator vs `/cc-cmds:design`: the input alone resolves most questions; only edge cases need user input.
+
+When the context is sufficient, confirm with the user briefly before proceeding to team composition.
+
+## Step 2: Team composition proposal (Korean)
+
+Propose a 2-teammate team to the user, both `opus`. Typical roles:
+
+- **FE Integration Architect** (opus): owns codebase integration — component mapping, state management, routing, file layout. Reads existing components to find reuse opportunities.
+- **DS Fidelity Reviewer** (opus): owns token/component fidelity — verifies the impl-design respects the DS-copy vs `var()`-reference pattern detected by design-ingest, calls out divergence risk, audits state coverage and accessibility-from-DS-semantics carrying through.
+
+Adjust roles based on the feature's character (e.g., if the feature is data-heavy, replace one role with a Data Flow specialist). Only create the team after the user approves the composition.
+
+## Step 3: Implementation-design discussion (English, internal)
+
+**Before assigning any team work, `Read ${CLAUDE_SKILL_DIR}/../_common/agent-team-protocol.md`.** Apply the completion-signal instruction and facilitator rules from that file throughout this step. When you assign work to each teammate via `SendMessage`, include the Teammate Rules block from `_common/agent-team-protocol.md` **verbatim in the assignment body** (the block-quoted teammate-facing instruction under the `## Teammate Rules` heading) — do NOT paraphrase to a one-liner.
+
+- Create the team with the approved composition. Team name: **`design-apply-{slug}`** (e.g., `design-apply-profile-settings`).
+- All inter-agent discussion in English.
+- **NO code modifications.** This is a design step that produces `impl-design.md` only.
+- Lead acts as facilitator, driving multi-round discussion.
+
+### Discussion protocol (minimum 2 full rounds)
+
+1. **Round 1 — Initial Proposals**: Assign each teammate their scope (FE Integration Architect → component mapping + state + routing + file layout proposal; DS Fidelity Reviewer → token/component usage rules + accessibility-preservation strategy + test strategy proposal). Wait for ALL teammates to submit `[COMPLETE]` proposals before proceeding. If a teammate sends `[IN PROGRESS]`, apply the facilitator counter / hard prompt rules from `_common/agent-team-protocol.md`.
+2. **Quality gate**: Verify each proposal references specific files/modules/patterns from the actual codebase (not generic advice) and includes concrete design decisions with rationale. Send shallow proposals back with specific deepening questions.
+3. **Round 2 — Cross-Review**: Send each teammate's proposal to the other for review. Identify gaps, risks, contradictions, and alternative approaches. Wait for `[COMPLETE]` from both.
+4. **Round 3+ — Refinement (as needed)**: Collect cross-review feedback and forward to the original authors. Repeat until convergence.
+5. **Convergence Check**: Use the convergence-check template from `_common/agent-team-protocol.md`. Only proceed to Step 4 when BOTH teammates confirm `[COMPLETE] No further input` via `SendMessage`.
+
+### Decisions in scope
+
+- **Component mapping**: which Claude Design prototype components map to which codebase components (existing or new); when to extract a new shared component vs inline; how to translate JSX from the bundle into the target stack's idiom.
+- **State management**: where each component's state lives (local / context / global store / URL); data flow for forms and interactions in the prototype.
+- **Routing**: how the bundle's `pages[]` (with their `route` fields) integrate into the codebase's routing approach.
+- **File layout**: where new files land (component directories, hooks, utils, styles); naming conventions; the boundary between feature-local and shared code.
+- **Token / component usage rules**:
+    - **Case (a) DS-copy-bundled**: do we vendor the DS `.css` into the codebase per-feature, or reference the canonical `docs/design-system/tokens.css` from a central place? How do we propagate DS version updates?
+    - **Case (b) `var()`-reference-only**: how is the DS CSS loaded in the codebase to make `var(--name)` references resolvable? Is it a global stylesheet, a token-only module, or a CSS-in-JS provider?
+    - Either case: how do we prevent feature code from re-declaring `:root` blocks (the contract from the paste prompt — `var()`-only).
+- **Test strategy**: if the project has Jest / Vitest / Playwright / RTL, propose specific test files and scenarios (unit tests for new components, integration tests for flows, accessibility snapshots if applicable). If the project has no test setup, note the absence and propose a scoped addition only if the user signals it's wanted (do NOT push a test framework on a project that lacks one).
+- **Color-space normalization** (deferred from `design-ingest`): if `tokens.css` carries `oklch(...)` values and the target stack's tooling doesn't support oklch, propose the conversion approach (browser support fallback, build-time conversion, hex/rgb fallback values).
+
+### MCP usage
+
+- **Sequential Thinking MCP** is permitted but not required for this skill.
+- **Claude Context MCP** for broad codebase queries is permitted; lite-tier MCP restrictions do not apply (this skill is in the heavy-tier alongside `/design`).
+- **context7 MCP** for target-stack documentation lookups is appropriate when the team is making decisions about specific library APIs (e.g., React Router patterns, Zustand store shape).
+
+## Step 4: Synthesis and documentation (Korean)
+
+- Lead synthesizes the discussion results into `docs/{slug}-fe/impl-design.md`. The document follows the standard 4-section Korean structure:
+    - 합의된 아키텍처
+    - 주요 결정사항과 근거
+    - 미해결 이슈 / 트레이드오프
+    - 권장 구현 순서
+- Pin the DS manifest version at the top of the file via HTML comment: `<!-- DS manifest version (consumed by design-apply): <version> -->`. This is the version used during this design synthesis; `/cc-cmds:implement` reads it on next invocation to detect drift between design and implementation.
+- **Synthesis terminal**: All teammate clarifications must be completed before saving `impl-design.md`. Once the file is saved, the synthesis phase is over — no further teammate messages are permitted. The sequence **save → cleanup → presentation** is atomic. Do NOT save a partial document, send a teammate message, then save again; clarify before the first save.
+- Notify the user in Korean: *"적용 설계 문서 저장을 완료했습니다. 팀을 정리한 뒤 결과를 공유드리겠습니다."*
+- **Before presenting results to the user, `Read ${CLAUDE_SKILL_DIR}/../_common/team-cleanup.md`** and follow the 5-step shutdown procedure to clean up the `design-apply-{slug}` team. The cleanup recovery anchor is the `{slug}` parsed from the input path in "Input parsing and slug recovery" above — `_common/team-cleanup.md`'s idempotency guards use this to safely no-op if cleanup already ran.
+- Present the results to the user in Korean.
+
+## Step 5: Korean next-step emit
+
+> "적용 설계 작성 완료: `docs/{slug}-fe/impl-design.md` (기준 DS 버전: `<version>`).
+>
+> 다음 단계: `/cc-cmds:design-review docs/{slug}-fe/impl-design.md`로 구현 세부 사항을 검증한 뒤, `/cc-cmds:implement docs/{slug}-fe/impl-design.md`로 구현을 시작하세요."
+
+Substitute `{slug}` and `<version>` with actual values.
+
+## DS drift detection
+
+At Step 1, after Reading `manifest.json`, compare the live `manifest.json.version` with the version pinned in `<handoff-extract-path>` (the design-ingest extract carries a `<!-- DS manifest version (live at ingest): <X> -->` comment). If they differ, emit a Korean warning in Step 1's confirmation message:
+
+> "⚠️ DS 버전 변경 감지: design-ingest 시점 `<old>` → 현재 `<new>`. 적용 설계는 현재 DS를 기준으로 합니다. 이전 DS와의 차이가 클 경우 design-ingest 재실행을 고려하세요."
+
+Do not block; the user decides. The team in Step 3 makes integration decisions against the current DS regardless.
+
+## Lightweight-sibling rationale (no `## Control-Flow Invariants` heading needed)
+
+This skill is an agent-team workflow (like `/cc-cmds:design` and `/cc-cmds:review`). Its termination contract lives in `_common/team-cleanup.md` — the 5-step shutdown procedure with idempotency guards. There is no in-session bash-variable termination formula at the SKILL.md level, so the skill is EXEMPT from `lint-skill-invariants.sh` rule (A) on the same grounds as `design`, `design-lite`, `review`, and `review-lite` (all currently exempt). The slug-from-input-path recovery key makes this exemption safe across interrupted runs.
+
+## Constraints
+
+- NO code modifications outside the saved `docs/{slug}-fe/impl-design.md`. The team discusses and the lead writes the design document; no source code is touched.
+- Inter-agent communication must be in English.
+- User-facing communication and the saved document in Korean.
+- Agent Team required: `TeamCreate` + `SendMessage` only. Do NOT substitute with isolated `Agent()` sub-agents for the discussion. (The Step 1 codebase exploration can use `Agent()` for parallel searches; only the Step 3 design discussion is constrained to TeamCreate.)
+- **Deferred tool loading**: Before using `AskUserQuestion`, `TeamCreate`, `SendMessage`, or `TeamDelete`, you MUST load them via `ToolSearch`. Run `ToolSearch` with queries `select:AskUserQuestion`, `select:TeamCreate`, `select:SendMessage`, and `select:TeamDelete` to load each tool. `AskUserQuestion` MUST be loaded before Step 1 (the optional narrow interview).
+
+Handoff extract path: $ARGUMENTS

--- a/plugins/cc-cmds/skills/design-ingest/SKILL.md
+++ b/plugins/cc-cmds/skills/design-ingest/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: design-ingest
+description: Claude Design (claude.ai/design) 핸드오프 번들을 파싱·리뷰하고 ACCEPT/REFINE 판정으로 개선 루프 진행
+when_to_use: claude.ai/design 에서 받은 HTML 핸드오프 번들을 검토·수용·재프롬프트할 때 (단일 호출 또는 외부 재실행 사이 반복)
+disable-model-invocation: true
+usage: "/cc-cmds:design-ingest <handoff-dir-path>"
+options:
+    - name: "<handoff-dir-path>"
+      kind: positional
+      required: true
+      summary: "기능 핸드오프 디렉토리 (`docs/{slug}-fe/handoff`); incoming/ 하위 번들을 소비"
+---
+
+Parse a Claude Design (claude.ai/design) handoff bundle, run a single-Agent quality review against the 5-axis criteria, and emit an ACCEPT or REFINE verdict. The skill is the **suspend-resume bridge** across the external manual loop — each invocation is fresh-context, all state lives on disk, and the outer feedback loop spans multiple `/cc-cmds:design-ingest` invocations interleaved with external Claude Design re-runs.
+
+The verdict contract: `critical` or `major` issues identified by the reviewing Agent → `REFINE`; zero such issues → `ACCEPT`. REFINE writes a `reprompt.md` the user pastes back into Claude Design for the next round. ACCEPT copies the round's `handoff-extract.md` to the stable path `docs/{slug}-fe/handoff-extract.md` so downstream `/cc-cmds:design-apply` has a deterministic input. The loop has a soft cap of 3 rounds (`ITER_CAP`); the 4th round opens an `AskUserQuestion` for continue / force-ACCEPT / abort.
+
+**Loop state is recovered from disk on every invocation** — no in-session counter, no compaction-fragile variable. The skill enumerates `iter-NNN/` directories under the handoff path, reads the `## Verdict:` header from the latest `review.md`, and decides next action from that plus the presence of `incoming/` sub-directories. The recovery anchor is the `## Verdict: ACCEPT|REFINE` header on the first line of each `review.md`.
+
+Two DS-usage patterns coexist in feature bundles and the skill branches on them:
+
+- **(a) DS-copy-bundled** (common, observed 5/6): the feature bundle ships a copy of the DS `.css` alongside its own HTML. `token_blocks[]` is non-empty. The skill **byte-diffs** the bundled copy against `docs/design-system/tokens.css`; any drift becomes a REFINE-eligible issue surfaced to the reviewing Agent.
+- **(b) `var()`-reference-only** (rare): the feature bundle has no `:root` declarations of its own (`tokens_absent: true`) and refers to DS tokens purely via `var(--name)`. The skill checks every entry in `referenced_undefined_vars[]` against `docs/design-system/tokens.css`; any var not present there becomes a REFINE-eligible issue.
+
+Both are normal cases. Neither blocks parsing; both are surfaced to the reviewing Agent as 5-axis input. `MALFORMED` from the parser is a separate, structural condition (no readable root, no README, no HTML) that does block ACCEPT and routes to user escalation via `AskUserQuestion`.
+
+User-facing strings are Korean; internal control prose is English. `web-design-guidelines` is invoked **optionally** by the reviewing Agent — absence does not halt review.
+
+## Step 1: Parse input and load shared contracts
+
+- Extract `{slug}` from `<handoff-dir-path>`. The path must match `docs/{slug}-fe/handoff` (the trailing component `handoff` is required; `{slug}-fe` carries the slug). On any other shape emit Korean error: *"입력 경로는 `docs/<slug>-fe/handoff` 형식이어야 합니다."* and end.
+- Verify the DS workspace at `docs/design-system/manifest.json` exists. If absent emit Korean: *"DS 워크스페이스가 없습니다. 먼저 `/cc-cmds:design-system`을 실행하세요."* and end.
+- Read `docs/design-system/manifest.json` and capture the current `version` as `live_ds_version`.
+- Read the prior pinned version from `docs/{slug}-fe/cd-prompt.paste.md`'s first-line HTML comment (`<!-- DS manifest version: <X> -->`) as `prompt_ds_version`. If the file is absent emit Korean: *"`docs/{slug}-fe/cd-prompt.paste.md`이 없습니다. 먼저 `/cc-cmds:design-prompt docs/{slug}.md`를 실행하세요."* and end.
+- Compare `live_ds_version` vs `prompt_ds_version`. If they differ, queue a Korean drift warning (emit alongside the next-step message at the end of the run):
+  > "⚠️ DS 버전 변경 감지: prompt build `<prompt_ds_version>` → live `<live_ds_version>`. 이번 round의 번들은 prompt build 시점 DS 기준이라 일부 평가 결과(특히 동봉 사본 vs 정본 diff)가 그 차이를 반영합니다."
+- `Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md` and `Read ${CLAUDE_SKILL_DIR}/../_common/parse-handoff.md`. The parser contract is shared with `design-system` phase 2.
+
+## Step 2: Recover loop state from disk
+
+Enumerate `<handoff-dir-path>/iter-*/` directories. Each directory name follows the zero-padded form `iter-NNN` (`iter-001`, `iter-002`, ...). Compute:
+
+- `last_iter` = max `NNN` among existing `iter-NNN/` dirs, or `0` if none exist.
+- `last_verdict` = read the first line of `iter-{last_iter}/review.md` (if `last_iter > 0` and the file exists). Match `^## Verdict: (ACCEPT|REFINE)` (case-sensitive). If `last_iter == 0` or the file is absent, `last_verdict = null`.
+- `has_new_bundle` = `find <handoff-dir-path>/incoming -mindepth 1 -maxdepth 1 -type d` yields at least one directory.
+
+Branch on `(has_new_bundle, last_verdict)`:
+
+- **`has_new_bundle == true`** → proceed to **Step 3 (new round)** with `next_N = last_iter + 1` (or `1` if `last_iter == 0`).
+- **`has_new_bundle == false` AND `last_verdict == REFINE`** → emit Korean: *"이전 round verdict가 REFINE입니다. `<handoff-dir-path>/iter-{last_iter:03d}/reprompt.md`를 claude.ai/design에 다시 붙여넣어 실행한 뒤, 새 번들을 `<handoff-dir-path>/incoming/`에 드롭하고 다시 `/cc-cmds:design-ingest`를 실행하세요."* (+ queued drift warning, if any.) End.
+- **`has_new_bundle == false` AND `last_verdict == ACCEPT`** → emit Korean: *"이미 ACCEPT 상태입니다. 안정 사본: `docs/{slug}-fe/handoff-extract.md`. 다음 단계: `/cc-cmds:design-apply docs/{slug}-fe/handoff-extract.md`."* End.
+- **`has_new_bundle == false` AND `last_verdict == null`** → emit Korean: *"먼저 claude.ai/design에서 번들을 다운로드해 `<handoff-dir-path>/incoming/`에 드롭하세요."* End.
+
+Substitute `{last_iter:03d}` with zero-padded 3-digit form.
+
+## Step 3: New-round processing
+
+### Step 3.1: ITER_CAP gate
+
+If `next_N > 3`, open `AskUserQuestion` with three options before doing any work:
+
+- (Recommended) "계속 진행" — proceed with this round normally; the cap is a soft cap and the user is overriding it.
+- "현재 상태로 ACCEPT 강제" — skip parsing/review, copy the most recent `iter-{last_iter}/handoff-extract.md` to the stable path, emit ACCEPT next-step. Suitable when the user has decided iteration has converged "enough".
+- "중단" — leave `incoming/` untouched and end.
+
+`ITER_CAP = 3` is the default. The user can always proceed past it; this prompt exists to break runaway loops.
+
+### Step 3.2: Bundle root selection and archival
+
+- `find <handoff-dir-path>/incoming -mindepth 1 -maxdepth 1 -type d` and pick the most-recently-modified directory as `{bundle-root}`. If multiple sub-directories are present, `AskUserQuestion` confirms ("`incoming/`에 N개 번들이 있습니다. 가장 최근(`<name>`)을 처리할까요?") with options (most-recent / pick-one / abort).
+- `mkdir -p <handoff-dir-path>/iter-{next_N:03d}/bundle` and `mv {bundle-root}/* <handoff-dir-path>/iter-{next_N:03d}/bundle/`. Then remove the now-empty `{bundle-root}` directory and confirm `<handoff-dir-path>/incoming/` has zero sub-directories (consumed signal).
+- Refer to the archived bundle path as `<handoff-dir-path>/iter-{next_N:03d}/bundle` for the rest of the round.
+
+### Step 3.3: Run the parser
+
+Follow the `parse-handoff.md` extraction contract on `<handoff-dir-path>/iter-{next_N:03d}/bundle`. The parser returns the uniform output record described in §8 of that file.
+
+If `status == "MALFORMED"`:
+
+- `AskUserQuestion` with options (edit-bundle-and-retry / re-download / abort). On any choice except "edit-and-retry", leave the archived bundle in place but do NOT write `review.md` or `handoff-extract.md` for this round — the round did not produce a verdict.
+- "edit-and-retry" prompts the user to fix the bundle in place under `iter-{next_N:03d}/bundle/` and re-run `/cc-cmds:design-ingest`; the skill will re-parse on next invocation.
+- End.
+
+If `record.kind_mismatch == true` (the bundle declares `kind: design-system` instead of `feature`), emit a Korean warning and confirm via `AskUserQuestion` whether the user intentionally wants to treat a DS bundle as a feature bundle. On decline, abort the round (leave files as-is, end). On confirm, proceed.
+
+### Step 3.4: DS-usage pattern detection (NOT rung-based)
+
+Branch on uniform-record content:
+
+- **Case (a) DS-copy-bundled** — `tokens_absent == false`. Run a byte-diff of every `token_blocks[i].raw_block_text` (filtered to `provenance == "authored-css"`) against the corresponding block in `docs/design-system/tokens.css` (matched by `(selector, theme_key)`). Any block that differs, plus any DS block missing entirely from the bundle, becomes a REFINE-eligible drift issue carried into Step 3.6.
+- **Case (b) `var()`-reference-only** — `tokens_absent == true`. For each entry in `record.referenced_undefined_vars[]`, check whether `--<name>` is declared anywhere in `docs/design-system/tokens.css`. Each missing var becomes a REFINE-eligible "undefined token" issue carried into Step 3.6.
+
+Both cases are normal; neither blocks. The skill records the case in `handoff-extract.md` so the reviewing Agent knows which pattern applies.
+
+### Step 3.5: Write `iter-{next_N}/handoff-extract.md`
+
+Emit a Korean markdown summary of the parser record + DS-usage analysis. Required sections:
+
+```
+<!-- DS manifest version (prompt build): <prompt_ds_version> -->
+<!-- DS manifest version (live at ingest): <live_ds_version> -->
+
+# Handoff extract — iter-{next_N:03d}
+
+## Parser status
+- status, contract_used, rungs_fired_per_field 요약
+
+## Bundle structure
+- primary, pages[] 요약 (file / title / route / provenance)
+- stack, theme_modes
+
+## Tokens (DS-usage pattern: <a | b>)
+- token_blocks 개수와 provenance 분포
+- (Case a) DS-copy-bundled — 동봉 사본 vs 정본 byte-diff 결과 (drift 블록 enumerate)
+- (Case b) var()-reference-only — referenced_undefined_vars 검증 결과 (DS에 없는 var enumerate)
+- token_groups divergent 표기 (있으면)
+
+## Components
+- components[] 요약 (name / stack_kind / source_file / provenance)
+
+## Unresolved questions (from parser)
+- record.unresolved_questions[] 그대로 인용
+
+## DS drift warning (있으면)
+- prompt_ds_version != live_ds_version 일 때만
+```
+
+The reviewing Agent in Step 3.6 reads this file as its primary input alongside the bundle itself.
+
+### Step 3.6: Single-pass reviewing Agent
+
+Spawn one fresh `Agent()` (subagent_type=`Explore` or `general-purpose`, single pass — NOT a team). Pass the following context:
+
+- The handoff-extract markdown just written (`iter-{next_N:03d}/handoff-extract.md`).
+- The bundle archive path (`iter-{next_N:03d}/bundle/`) — the Agent reads the primary HTML and any imports directly from disk.
+- The base design document `docs/{slug}.md` — for intent-fidelity assessment.
+- The DS workspace files `docs/design-system/{tokens.md, components.md, tokens.css}` — for the canonical token/component reference.
+
+Instruct the Agent to assess across **5 axes** and report `critical` / `major` / `minor` / `info` findings on each:
+
+1. **DS fidelity**: (Case a) bundled `tokens.css` vs canonical `docs/design-system/tokens.css` byte-diff outcomes — any drift; (Case b) `referenced_undefined_vars[]` resolution — any missing var. Component patterns match `components.md` contracts.
+2. **Accessibility — contrast ratios**: compute WCAG AA 4.5:1 for body text and 3:1 for large text using the actual token values (the Agent reads `:root` blocks and resolves `var()` references). Report any color pair that fails for an interactive element.
+3. **Responsive / touch targets**: minimum touch target 44px square (WCAG 2.5.5); responsive breakpoints make sense for the page's role; no horizontal scroll at common widths.
+4. **Base intent fidelity**: the prototype's pages and flows match the intent in the base design document's "Claude Design 프롬프트 + 컨텍스트" section (특히 의도 + 페이지/플로우 의도 sub-blocks).
+5. **General visual quality**: rendering looks plausible; no obvious broken layouts, missing states, or placeholder content; component states (hover/focus/disabled) are demonstrated.
+
+**Optional dependency — `web-design-guidelines`**: If the skill `web-design-guidelines` is available in the environment, instruct the Agent to invoke it for axes 2, 3, 5 as a structured checklist source. If it is not available, the Agent performs axes 2, 3, 5 from its own judgment using the 5-axis criteria above. **Absence does NOT halt review.** The Agent should not error or stall on `web-design-guidelines` unavailability; it proceeds with the local criteria. This optional dependency is also declared in the README "Prerequisites" section.
+
+`divergent` token groups from the parser are passed as a REFINE-eligible signal but **not** auto-rejected. Per-screen divergence is sometimes intentional in feature bundles (unlike DS bundles where divergence is structural error). The Agent decides whether divergence is intentional or a defect and reports accordingly.
+
+`unresolved_questions[]` from the parser are passed for the Agent to either integrate into a REFINE message or surface as informational notes alongside an ACCEPT.
+
+The Agent's deliverable is a structured report grouping findings by axis and severity, plus an overall verdict line.
+
+### Step 3.7: Verdict computation
+
+The verdict is decided by structural rule, not the Agent's overall opinion:
+
+- If the Agent reports at least one `critical` or `major` finding → **REFINE**.
+- Otherwise → **ACCEPT**. `minor` and `info` are non-blocking; they may be carried into `handoff-extract.md` or `review.md` as notes but do not flip the verdict.
+
+This rule is the load-bearing contract of the skill — see also the "EXEMPT rationale" below for why it stays in body prose rather than under a `## Control-Flow Invariants` heading.
+
+### Step 3.8: Write `iter-{next_N:03d}/review.md`
+
+The first line is the verdict header in the exact form the disk-recovery logic in Step 2 matches:
+
+```
+## Verdict: ACCEPT
+```
+
+or
+
+```
+## Verdict: REFINE
+```
+
+Below the header, write the Agent's structured report verbatim (or lightly reformatted as Korean prose with English finding labels — the Agent may write in either; what matters is the verdict header).
+
+### Step 3.9: REFINE branch
+
+If verdict is REFINE:
+
+- Write `iter-{next_N:03d}/reprompt.md`. This file is what the user pastes into claude.ai/design for the next round. Compose it from:
+    - Line 1: `<!-- DS manifest version: <live_ds_version> -->` (re-pin to live, since this is what the next round should target).
+    - A 1-line Korean intro: *"이전 round 번들에 must-fix 이슈가 발견되어 재실행한다. 동일 HANDOFF CONTRACT와 DS 참조를 유지하되, 아래 must-fix 이슈를 모두 해결해라."*
+    - The full byte-verbatim contents of `docs/{slug}-fe/cd-prompt.paste.md` (the original prompt — re-quoted to make `reprompt.md` self-contained for the external paste).
+    - A new English section `### Must-fix issues from previous round` listing every `critical`/`major` finding from the Agent's report, grouped by axis, with brief one-line explanations.
+    - Optional `### Carry-over informational notes` listing `minor`/`info` findings if any seem relevant for the next round.
+- Korean next-step emit: *"Verdict: REFINE. must-fix 이슈가 `iter-{next_N:03d}/review.md`에, 재프롬프트가 `iter-{next_N:03d}/reprompt.md`에 작성됐습니다. `reprompt.md`를 claude.ai/design에 붙여넣어 재실행한 뒤, 새 번들을 `<handoff-dir-path>/incoming/`에 드롭하고 다시 `/cc-cmds:design-ingest`를 실행하세요."* (+ queued drift warning, if any.) End.
+
+### Step 3.10: ACCEPT branch
+
+If verdict is ACCEPT:
+
+- `cp iter-{next_N:03d}/handoff-extract.md docs/{slug}-fe/handoff-extract.md` (this is the stable anchor `design-apply` reads).
+- Korean next-step emit: *"Verdict: ACCEPT. 안정 사본: `docs/{slug}-fe/handoff-extract.md`. 다음 단계: `/cc-cmds:design-apply docs/{slug}-fe/handoff-extract.md`."* (+ queued drift warning, if any.) End.
+
+## ITER_CAP recap (prominent body prose)
+
+The default `ITER_CAP` is **3**. The cap is enforced in Step 3.1, before any parsing or review work, by checking `next_N > 3`. The user always has the option to override and proceed; the cap exists to interrupt runaway loops, not to enforce a hard rule. The disk recovery in Step 2 naturally handles re-runs after a cap override — the verdict header from `iter-003/review.md` (or higher) remains the recovery anchor.
+
+## Verdict-recovery contract (prominent body prose)
+
+The first line of every `iter-NNN/review.md` matches the regex `^## Verdict: (ACCEPT|REFINE)$` exactly. This is the only recovery anchor; the skill never relies on in-session state to know "where we are in the loop." Compaction-fragile in-session variables (counters, flags) are intentionally absent. The verdict header + the iter-directory enumeration is sufficient to recover.
+
+## EXEMPT rationale (no `## Control-Flow Invariants` heading needed)
+
+This skill is a single-pass verdict emitter (the `review` family), and its loop state lives entirely on disk (the `## Verdict:` header on the first line of each `iter-NNN/review.md`, plus directory enumeration). Every invocation is fresh-context; there is no in-session bash variable that compaction could erase. The ACCEPT/REFINE rule, `ITER_CAP`, and user-gated exit are all kept in prominent body prose (Steps 3.1, 3.7, "ITER_CAP recap", "Verdict-recovery contract" sections above) rather than under a `## Control-Flow Invariants` heading — the same pattern `/design` Step 5/6 uses for file-recovery state. The skill is therefore EXEMPT from `lint-skill-invariants.sh` rule (A).
+
+## Constraints
+
+- NO code modifications outside `docs/{slug}-fe/handoff/` and `docs/{slug}-fe/handoff-extract.md`.
+- User-facing strings in Korean; internal control prose in English; the reviewing Agent's report language follows what the Agent itself chooses (commonly English findings with brief Korean prose at the top).
+- `web-design-guidelines` is OPTIONAL. The skill must not hard-invoke it; absence triggers fallback to the local 5-axis criteria. Declared in README "Prerequisites" alongside `terminal-notifier` (the precedent for optional skills in cc-cmds).
+- The verdict computation is structural (count of `critical`/`major` findings ≥ 1 → REFINE), not the Agent's own ACCEPT/REFINE opinion. The Agent reports findings; the skill computes the verdict.
+- DS workspace files are read-only here; `design-ingest` never modifies `docs/design-system/`.
+- **Deferred tool loading**: Before using `AskUserQuestion`, you MUST load it via `ToolSearch("select:AskUserQuestion")`. The skill assumes no other deferred tool beyond that.
+
+Handoff directory: $ARGUMENTS

--- a/plugins/cc-cmds/skills/design-prompt/SKILL.md
+++ b/plugins/cc-cmds/skills/design-prompt/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: design-prompt
+description: Claude Design (claude.ai/design) 실행용 프롬프트+컨텍스트를 base 설계 문서에 authoring하고 붙여넣기 블록 emit (standalone + idempotent, HANDOFF CONTRACT 포함)
+when_to_use: base 설계 작성 후, claude.ai/design 에 보낼 의도 중심 프롬프트와 DS 참조를 base 설계 문서에 추가하거나 리뷰 반영본으로 붙여넣기 블록을 재조립할 때
+disable-model-invocation: true
+usage: "/cc-cmds:design-prompt <base-doc-path>"
+options:
+    - name: "<base-doc-path>"
+      kind: positional
+      required: true
+      summary: "base 설계 문서 경로 (`docs/{slug}.md`); 본 스킬이 그 안에 CD 프롬프트 섹션을 in-place authoring"
+---
+
+Author the "Claude Design 프롬프트 + 컨텍스트" section inside the **base design document** — the single markdown at `docs/{slug}.md` that `/cc-cmds:design` first created and that this skill now extends to carry the Claude Design prompt as well. The base design document is the durable per-feature carrier: `/cc-cmds:design` writes the base sections, `/cc-cmds:design-prompt` adds the prompt section, and `/cc-cmds:design-review --base` audits the whole file as one for consistency.
+
+The skill also emits a derived paste block at `docs/{slug}-fe/cd-prompt.paste.md` — a self-contained file the user pastes into claude.ai/design. The base design document is the source of truth; the paste block is rebuilt from it on every invocation.
+
+The skill is **standalone and idempotent** — re-invocations replace the prompt section in place (no append, no duplication) and rebuild the paste block from the current base-document state. This survives `design-review --base` edits and user touch-ups between rounds.
+
+User-facing strings are Korean; internal control prose is English.
+
+## Step 1: Parse input and verify DS workspace
+
+- Extract `{slug}` from `<base-doc-path>`. The path must match `docs/{slug}.md`; the file stem is `{slug}`. On any other shape (no `docs/` prefix, no `.md` extension, multi-segment stem) emit Korean error: *"입력 경로는 `docs/<slug>.md` 형식이어야 합니다."* and end.
+- Verify the DS workspace at `docs/design-system/manifest.json` exists. If absent, emit Korean: *"먼저 `/cc-cmds:design-system`으로 DS 워크스페이스를 구축하세요. `design-prompt`는 DS의 토큰·컴포넌트 카탈로그를 참조합니다."* and end.
+- Read `docs/design-system/manifest.json` and capture the current `version`. This is the DS version `design-prompt` will pin into both outputs (the base-document section and the paste block).
+
+(The skill `design-system` and the workspace directory `docs/design-system/` share a token but live in different namespaces. When referring to either, qualify in prose to avoid conflation.)
+
+## Step 2: In-place author the prompt section inside the base design document
+
+The base design document `docs/{slug}.md` carries the Claude Design prompt as one of its sections, with a stable heading anchor so re-runs replace cleanly.
+
+- **Anchor heading**: `## Claude Design 프롬프트 + 컨텍스트` (exact string, no decoration, no version suffix).
+- Read the base design document.
+- If the anchor exists, replace **the section body** (everything between this heading and the next `^## ` heading or EOF). Do not append; do not duplicate; do not touch other sections — `design-review --base` and the user may have edited surrounding content between rounds and that must survive.
+- If the anchor does not exist, append the entire section at the end of the document.
+
+The section body contains three sub-blocks, separated by blank lines:
+
+1. **의도 (Korean prose)** — A re-interpretation of the base design's core direction in 2–4 paragraphs, written by the lead. This is the source of truth that `design-review --base` audits for consistency.
+2. **DS 참조 (Korean prose with file path mentions)** — Cite which DS assets this feature depends on: `docs/design-system/tokens.md` for token semantics, `docs/design-system/components.md` for component contracts, and the DS `version` from `manifest.json`. Do NOT inline token values here; the paste block carries them. Include the DS manifest version inline as: *"기준 DS 버전: `<version>`."*
+3. **페이지 / 플로우 의도 (Korean prose)** — Which pages, flows, and interactions the feature requires. Page-level intent; not implementation detail.
+
+After the section is written/replaced, the base design document is the carrier of the prompt intent; `design-review --base` audits it as one document for intent and DS-reference consistency, never inspecting the paste block.
+
+## Step 3: Assemble the paste block `docs/{slug}-fe/cd-prompt.paste.md`
+
+This is the file the user pastes into claude.ai/design. It must be self-contained — Claude Design has no access to the base design document on disk.
+
+- Create `docs/{slug}-fe/` if it does not exist. Do not touch other files inside it.
+- Overwrite `docs/{slug}-fe/cd-prompt.paste.md` (re-runs are intentional rebuilds).
+- The file is composed of, in order:
+
+### Line 1 (HTML comment): DS version pin
+
+```
+<!-- DS manifest version: <version> -->
+```
+
+`design-ingest` reads this comment back later to detect DS drift between prompt build time and ingest time.
+
+### Block (a) — Korean intro (1 short line)
+
+> "다음은 cc-cmds 파이프라인이 부과한 핸드오프 계약과 기능 프롬프트다. README frontmatter를 반드시 채워서 번들에 포함해라."
+
+### Block (b) — HANDOFF CONTRACT (English + YAML)
+
+`Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md` and quote its schema block **verbatim**. Append a one-paragraph English instruction:
+
+> "Place this YAML frontmatter at the top of the **inner** README of your bundle — the README inside the content folder alongside your HTML files. The outer 'CODING AGENTS' README must remain the human-facing document; do not modify it. Set `kind: feature` and `feature: {slug}`. Fill `primary`, `pages[]`, `tokens_file`, and `theme_mode[]` based on the pages you actually generate. Every field is cross-checked against the bundle's real files by the downstream parser; do not lie."
+
+Substitute `{slug}` with the actual slug.
+
+### Block (c) — DS reference (English instruction + verbatim CSS + components excerpt)
+
+- One-line English instruction: *"Use only the tokens and component contracts below. Do not invent new tokens or component patterns. Reference tokens via `var(--token-name)` in your HTML; do not re-declare `:root` blocks in your feature bundle."*
+- A fenced code block (` ```css `) containing the **full byte-verbatim contents of `docs/design-system/tokens.css`**. The `design-system` phase 2 synthesized this file with wrappers preserved and provenance comments inline; quote it as-is. Do not strip comments, do not re-order, do not normalize values.
+- An English heading `### Component contracts` followed by an excerpt of `docs/design-system/components.md` covering the components this feature is likely to need (lead's judgment based on Step 2's page/flow intent). If unsure, quote the entire `components.md`. Preserve the source file's markdown formatting.
+
+### Block (d) — Feature intent (Korean prose, quoted from the base document section)
+
+Quote the **의도** and **페이지 / 플로우 의도** sub-blocks from the Step 2 section verbatim (the lead-authored Korean prose). Do not re-summarize — the base design document is the source of truth.
+
+### Block (e) — Output guidelines (English instruction list)
+
+A bulleted list:
+
+- "Do NOT place `:root { ... }` blocks in feature HTML pages. Reference DS tokens via `var(--token-name)`."
+- "If you create additional pages beyond the primary, list every page in the frontmatter `pages[]` array with `file`, `title`, `route`."
+- "Set `theme_mode: ["light", "dark"]` if your feature supports both themes; `["light"]` otherwise."
+- "Wrap dark-theme overrides in either `:root[data-theme="dark"]` or `@media (prefers-color-scheme: dark) { ... }`. Never strip the wrapper around a `:root` block."
+- "Use the same stack family as the DS (`react` if the DS used React 18 CDN, etc.); the downstream parser detects stack from HTML signatures and warns on mismatch."
+
+## Step 4: DS drift detection on re-runs
+
+If this is a re-run (the section anchor existed before Step 2 ran), compare the **previously pinned DS version** (extract from the section's "기준 DS 버전:" line before overwriting) with the **current** `manifest.json.version`.
+
+If they differ:
+
+- Emit a Korean warning prose just before the next-step message:
+  > "⚠️ DS 버전 변경 감지: 직전 빌드 `<old>` → 현재 `<new>`. 재조립된 `cd-prompt.paste.md`는 현재 DS를 인용합니다. 이미 claude.ai/design에서 외부 실행 중인 라운드가 있다면 그 산출물은 직전 DS 기준이므로, `design-ingest`가 drift를 감지하면 그때 의사결정하세요."
+- Do not block; the user decides whether to regenerate or proceed.
+
+## Step 5: Korean next-step emit
+
+> "CD 프롬프트 섹션을 `docs/{slug}.md`에 in-place authoring하고 붙여넣기 블록을 `docs/{slug}-fe/cd-prompt.paste.md`에 작성했습니다.
+>
+> 다음 단계: `/cc-cmds:design-review --base docs/{slug}.md`로 base 설계 문서 전체 일관성을 검증하세요. 리뷰가 반영되면 `/cc-cmds:design-prompt`를 다시 실행해 붙여넣기 블록을 재조립한 뒤, `docs/{slug}-fe/cd-prompt.paste.md`를 claude.ai/design에 붙여넣어 실행하세요."
+
+Substitute `{slug}` with the actual slug.
+
+## Idempotency contract
+
+- The section anchor is `## Claude Design 프롬프트 + 컨텍스트`. Two re-runs from identical inputs produce identical section content (deterministic) and an identical paste block.
+- Re-runs **never append** under any condition. They replace the section body in place and overwrite the paste block.
+- The paste block is a **derived artifact**; the base design document section is the **source of truth**. `design-review --base` audits the base document; it never audits the paste block.
+
+## EXEMPT rationale (no `## Control-Flow Invariants` heading)
+
+Linear authoring with idempotent in-place replacement. No loop, no termination counter, no in-session variable. Exempt from `lint-skill-invariants.sh` rule (A) on the same grounds as `design-system`.
+
+## Constraints
+
+- NO code modifications outside `docs/{slug}.md` (in-place section edit) and `docs/{slug}-fe/cd-prompt.paste.md` (overwrite).
+- User-facing strings in Korean; internal control prose in English; the paste block mixes English (instructions for Claude Design) and Korean (feature intent quoted from the base document section).
+- Quote `tokens.css` byte-verbatim — never re-order, normalize, or strip wrappers from `:root` blocks.
+- DS `manifest.json` is read-only here; `design-prompt` never writes to the DS workspace.
+- This skill is fully deterministic from disk inputs and does NOT call `AskUserQuestion`. No deferred-tool loading required.
+
+Base design document: $ARGUMENTS

--- a/plugins/cc-cmds/skills/design-system/SKILL.md
+++ b/plugins/cc-cmds/skills/design-system/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: design-system
+description: Claude Design (claude.ai/design) DS 생성 프롬프트 emit + DS 번들 ingest로 docs/design-system/ 워크스페이스 구축 (2-phase)
+when_to_use: FE 파이프라인 시작 전 프로젝트 전역 design system을 claude.ai/design으로 생성·도입할 때 (1회성 또는 재ingest)
+disable-model-invocation: true
+usage: "/cc-cmds:design-system [<intent>]"
+options:
+    - name: "[<intent>]"
+      kind: positional
+      required: false
+      summary: "DS 생성 의도/스코프 서술용 자유형 토큰 (생략 시 base 설계·코드베이스에서 추론)"
+---
+
+Build the project-wide design system workspace at `docs/design-system/` by orchestrating a two-phase handoff with Claude Design (claude.ai/design). Phase 1 emits the DS-generation prompt the user pastes into Claude Design; phase 2 ingests the returned bundle and synthesizes `tokens.css`, `tokens.md`, `components.md`, and `manifest.json`. The two phases are separate slash invocations bridged by an external manual step — the user runs Claude Design, downloads the bundle, drops it under `docs/design-system/incoming/`.
+
+This skill **distinguishes the skill name `design-system` from the workspace directory `docs/design-system/`**. They share a token but live in different namespaces (skill directory vs docs directory). When recovering a fresh session, always qualify the workspace explicitly ("workspace `docs/design-system/`" vs "skill `design-system`") so the two are not conflated.
+
+User-facing strings (interviews, escalation, next-step emit) are Korean; internal control prose below is English.
+
+## Phase auto-detection
+
+On entry, inspect `docs/design-system/incoming/`:
+
+- Directory does not exist OR contains zero sub-directories → **phase 1 (prompt emit)**.
+- Directory contains at least one sub-directory → **phase 2 (ingest)**.
+
+Phase selection is read purely from disk state. There is no in-session phase flag; re-invoking after a successful phase 2 (which empties `incoming/`) cleanly returns to phase 1 behavior for the next intent. This file-recovery posture is why the skill is EXEMPT from `lint-skill-invariants.sh` rule (A): there is no in-session termination contract that post-conversation compaction could erase.
+
+## Phase 1 — DS-generation prompt emit
+
+### Step 1.1: Extract directional pre-answers as flexible Q&A pairs (Korean)
+
+Claude Design opens DS generation with an interactive directional-question form. **The form's categories, order, and wording are a variable artifact of the external tool** — a single point-in-time observation must not be hardcoded as a frozen contract (same doctrine as `parse-handoff.md`: don't bake one observation into the schema).
+
+Instead, **extract directional information abstractly** as a flexible list of `(topic, answer)` pairs. The shape:
+
+```
+- Topic: <human-readable label naturally derived from base design or codebase>
+  Answer: <concrete value or short prose>
+```
+
+The number of pairs and their order are variable. There is no required category list. Topics typically arise from base-design analysis (e.g., "브랜드 톤", "타이포 가족", "한국어 폰트", "컴포넌트 범위", "레퍼런스 URL", "테마 모드", "UI 밀도") but none of these are mandatory — extract only what the base design and codebase make concrete.
+
+Sources to mine, in priority order:
+
+1. The optional `<intent>` argument (free-form user text describing scope and direction).
+2. The project's base design document if one exists (any `docs/*.md` that touches visual direction, branding, design tokens, or component scope).
+3. The codebase itself (existing color tokens, font stacks, component naming, layout conventions — infer current direction from what is already there).
+
+Run a focused `AskUserQuestion` for any topic that none of these sources resolves and that you judge load-bearing for the DS. Ask one or two questions per topic; **do NOT enumerate a fixed category list to the user** — that would reproduce the frozen-contract anti-pattern. Stop the interview when no additional topic seems load-bearing; emit-time backfill via the relay loop covers the rest.
+
+It is acceptable for the resulting Q&A pair list to be empty (e.g., when the base design and codebase are silent on direction). Phase-1 emit still proceeds; Claude Design's own form will fill the gap at first use and the relay loop will route any escalation back through this session.
+
+### Step 1.2: Compose `ds-prompt.paste.md` (5 blocks, in order)
+
+- **Block (a) — Korean intro (top of file)**: A single short line: *"아래는 cc-cmds 파이프라인이 부과한 핸드오프 계약과 DS 생성 의도다. 계약 frontmatter는 그대로 inner README에 넣어달라."*
+- **Block (b) — DS-generation intent (Korean)**: 2–4 paragraphs synthesizing the base design, the `<intent>` argument, and the lead's re-interpretation of the project domain. This is descriptive prose, not enumeration.
+- **Block (c) — HANDOFF CONTRACT (English + YAML)**: `Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md` and quote its schema block verbatim. Append a one-paragraph English instruction: *"Place this YAML frontmatter at the top of the inner README of your bundle (the README inside the content folder alongside your HTML files). Set `kind: design-system`. The outer 'CODING AGENTS' README remains the human-facing document — do not touch it. Every field is cross-checked against the bundle's actual files by the downstream parser; do not lie."*
+- **Block (d) — DS structural requirements (English)**: Require `:root` CSS custom properties for all design tokens; prefer a shared `.css` file (e.g., `tokens.css`) for the token block; include a component catalog page that demonstrates each component in every state; support theming via `[data-theme="dark"]` or `@media (prefers-color-scheme: dark)` wrapper — never strip the wrapper.
+- **Block (e) — Directional pre-answers (variable Q&A pair list)**: Serialize the Q&A pairs from Step 1.1 in extracted order. Format each as `Topic: <topic>\nAnswer: <answer>` separated by blank lines. **Do not enumerate any required categories**; emit exactly the pairs Step 1.1 produced. Empty list is acceptable — emit a single sentinel line *"No directional pre-answers extracted; please ask all directional questions in the form, and the user will relay any unclear question to the cc-cmds session for a base-design-grounded answer."* in that case.
+
+Save the composed file to `docs/design-system/ds-prompt.paste.md`. Overwrite without confirmation if it already exists (phase-1 re-runs are intentional regenerations of the prompt).
+
+### Step 1.3: Emit relay-loop guidance (Korean)
+
+After writing the file, emit:
+
+> "DS 생성 프롬프트를 `docs/design-system/ds-prompt.paste.md`에 저장했습니다. claude.ai/design에 붙여넣어 실행해주세요.
+>
+> **CD가 띄우는 방향성 폼은 카테고리·순서가 가변이라 사전답변이 폼을 100% 커버하지 못할 수 있습니다.** CD가 사전답변 밖의 추가 질문을 던지면 그 질문을 이 세션에 그대로 전달해주세요 — base 설계와 코드베이스를 근거로 답안을 제시하겠습니다. 사용자가 그 답안을 CD 폼에 입력합니다. 완전 자동화는 외부 수동 단계 때문에 불가하므로, 이 relay 루프를 통해 의도가 끊기지 않게 유지합니다.
+>
+> DS 번들 다운로드가 끝나면 zip을 풀어 `docs/design-system/incoming/<bundle-name>/` 형태로 드롭하고, 다시 `/cc-cmds:design-system`을 실행하세요. phase 2가 자동으로 incoming/ 번들을 ingest합니다."
+
+End phase 1.
+
+## Phase 2 — DS bundle ingest
+
+### Step 2.1: Load shared contracts and select bundle root
+
+```
+Read ${CLAUDE_SKILL_DIR}/../_common/handoff-contract.md
+Read ${CLAUDE_SKILL_DIR}/../_common/parse-handoff.md
+```
+
+List sub-directories under `docs/design-system/incoming/` and select the most-recently-modified as `{bundle-root}`. If multiple sub-directories are present (user dropped several rounds), confirm via `AskUserQuestion`: *"`incoming/`에 번들이 N개 있습니다. 가장 최근(`<name>`, mtime: `<ts>`)을 ingest할까요?"* with options (most-recent / pick-one / abort).
+
+### Step 2.2: Apply the parser
+
+Follow the `parse-handoff.md` extraction contract end-to-end on `{bundle-root}`. The parser returns the uniform output record described in §8 of that file.
+
+### Step 2.3: Caller-side branching (uniform-record-based, NOT rung-based)
+
+Branch on record content. Never branch on which rung fired.
+
+- **`status == "MALFORMED"`** → `AskUserQuestion` with options (edit-bundle-and-retry / re-download / abort). Do NOT touch the workspace. Do NOT empty `incoming/`.
+- **`kind_mismatch == true`** (record's `kind` is `feature` or null instead of `design-system`) → emit Korean warning prose and confirm via `AskUserQuestion` whether the user intentionally wants to treat a non-DS bundle as DS source. On confirm proceed; on decline abort.
+- **`tokens_absent == true`** → **caller-level block.** A DS without `:root` token bytes has no substance to commit. Emit Korean escalation: *"번들에 `:root` 토큰 블록이 없어 DS 워크스페이스를 구축할 수 없습니다. Claude Design에 토큰을 명시적으로 요구하는 프롬프트로 재실행하거나, 다른 번들을 사용하세요."* Do NOT write `tokens.css`. Do NOT empty `incoming/`. End phase 2.
+- **Any `token_groups[i].divergent == true`** → **escalate.** A DS must be uniform per theme; divergent same-theme blocks mean the bundle contains contradictory token definitions across files. Emit Korean escalation listing the divergent theme keys and their source files; offer (retry-with-cleaner-prompt / pick-one-source-and-proceed / abort). Do NOT silently auto-collapse.
+
+If none of the blocking conditions fired, proceed to synthesis.
+
+### Step 2.4: Synthesize `tokens.css` (authored-css blocks only, wrapper-preserved)
+
+Produce a byte-verbatim valid CSS file that downstream skills (notably `design-prompt`) can quote without re-encoding.
+
+1. Filter `token_blocks[]` to entries with `provenance == "authored-css"`. Exclude `readme-derived` and `agent-inferred` — `tokens.css` is the verbatim-quote-safe surface.
+2. Sort: default theme first, then other themes in alphabetical order of `theme_key`. Within a theme, preserve the parser's source-file ordering.
+3. Deduplicate using `token_groups[]`: emit only the first block of each identical-bytes group; append `/* identical block also present in: <other source files> */` when N > 1.
+4. Above each emitted block, write a provenance header comment:
+   ```
+   /* source: <source_file> (origin: <inline-style | shared-file>, theme_key: <default | dark | ...>) */
+   ```
+5. Emit the **wrapper-inclusive `raw_block_text`** verbatim. Never strip `@media (prefers-color-scheme: dark)` or `:root[data-theme="dark"]` envelopes — stripping makes dark tokens apply unconditionally and breaks theme switching.
+6. Save the assembled content to `docs/design-system/tokens.css`. By construction the result is valid CSS (the parser's wrapper-inclusive captures guarantee this).
+
+### Step 2.5: Synthesize `tokens.md` (semantic catalog)
+
+Write `docs/design-system/tokens.md` as a Korean prose catalog. Group tokens by category headings (`### Colors`, `### Spacing`, `### Shadows`, `### Typography`, `### Radius`, ... — only the categories the bundle actually defines). For each token write a one-line row: `--token-name` → value → role. Inference-based rows are acceptable; non-`authored-css` derived tokens (e.g., picked up from a `readme-derived` table) may also appear here even though they were excluded from `tokens.css`.
+
+### Step 2.6: Synthesize `components.md` (component contracts)
+
+Write `docs/design-system/components.md` from `record.components[]`. For each component emit a section: name, stack kind, anatomy (composition prose), states (interaction states observed), a11y (ARIA attributes / focus management), usage (when to use, conventions). The records are lossy by design — fill anatomy and usage from the lead's reading of the bundle's HTML when the parser left them empty.
+
+### Step 2.7: Write `manifest.json`
+
+```json
+{
+  "version": "<YYYYMMDD-HHMMSS at ingest time>",
+  "source_bundle": "<bundle-root directory name>",
+  "ingested_at": "<ISO 8601 timestamp>",
+  "kind": "design-system",
+  "contract_used": <bool from record>,
+  "rungs_fired_per_field": <object copied from record>,
+  "theme_modes": ["light", "dark"],
+  "token_block_count": <int>,
+  "component_count": <int>,
+  "unresolved_questions": [<copied from record, informational>]
+}
+```
+
+The `version` field is the anchor `design-prompt` and `design-apply` pin via `<!-- DS manifest version: ... -->` comments and use for drift detection. It is monotonic per ingest by using the current timestamp.
+
+### Step 2.8: Archive the bundle and clear `incoming/`
+
+- `mv "{bundle-root}" "docs/design-system/bundles/<version>/"` (creating `bundles/` if needed). The version-named directory preserves the original Claude Design output for re-ingest and diff.
+- Empty `docs/design-system/incoming/` (the consumed signal — phase auto-detection on the next invocation must see no remaining sub-directories).
+
+### Step 2.9: Emit next-step (Korean)
+
+> "DS 워크스페이스 구축 완료: `docs/design-system/{tokens.css, tokens.md, components.md, manifest.json}` (version: `<version>`).
+>
+> 다음 단계: `/cc-cmds:design <slug>`로 base 우산 설계를 작성하세요. 이후 `/cc-cmds:design-prompt`가 이 DS를 자동으로 참조합니다."
+
+If the record contained non-blocking `unresolved_questions[]` (e.g., a missing `components` list in the contract, primary-page disambiguation note), append them as bullet points after the next-step line so the user can decide whether to act on them now or later. Non-blocking surfacing only — do not gate the next step on them.
+
+## Re-ingest safety
+
+Phase-2 re-runs overwrite `tokens.css`, `tokens.md`, `components.md`, `manifest.json` with the new bundle's contents. The `bundles/<old-version>/` archive is preserved as a sibling of the new archive. This is intentional — the user opts into a re-ingest by dropping a new bundle into `incoming/`.
+
+`design-prompt` and `design-apply` record the manifest `version` they consumed at their build time; if the live `version` differs at their next invocation, they emit a drift warning so the user can decide whether to regenerate downstream artifacts or proceed.
+
+## EXEMPT rationale (no `## Control-Flow Invariants` heading needed)
+
+This skill is linear in both phases. Phase auto-detection reads disk state on entry; there is no in-session loop variable, no termination counter, no compaction-fragile contract. Phase 1 emits a file and ends; phase 2 reads the parser record, branches once on its content, writes the workspace, and ends. The skill therefore belongs to the majority of skills exempted from `lint-skill-invariants.sh` rule (A), which targets only the `design-review ↔ design-review-lite` pair's inline bash-variable termination contract.
+
+## Constraints
+
+- NO code modifications outside `docs/design-system/`.
+- User-facing strings (interviews, escalation, next-step emit) in Korean; internal prose in English.
+- Token values are NEVER normalized. Preserve `oklch(...)`, `#rrggbb`, `rgb(...)`, `hsl(...)` exactly as Claude Design wrote them. Any color-space conversion belongs to `design-apply` at consumption time.
+- **No fixed-category enumeration in directional pre-answers.** The Q&A pair list is variable in count and order. Hardcoding a category list reproduces the stale-frozen-contract anti-pattern that `parse-handoff.md` already addresses for bundle structure.
+- `web-design-guidelines` is NOT invoked from this skill — it is `design-ingest`'s optional dependency, not the DS workspace's.
+- **Deferred tool loading**: Before using `AskUserQuestion`, you MUST load it via `ToolSearch("select:AskUserQuestion")`. This skill assumes no other deferred tool beyond that.
+
+Intent: $ARGUMENTS

--- a/scripts/lint-skill-invariants.sh
+++ b/scripts/lint-skill-invariants.sh
@@ -30,9 +30,23 @@ TOKEN_BUDGET=4000
 WORDS_PER_TOKEN_RATIO=1.3   # tokens ≈ words × 1.3 (conservative over-estimate)
 INVARIANT_HEADING='^## Control-Flow Invariants[[:space:]]*$'
 
-# Skills that are exempt from rule (A) — tiny orchestration-only skills that
-# have no outer/inner termination loop and cannot silently mis-terminate.
-EXEMPT_SKILLS=("active-notify" "design-upgrade" "implement" "design" "review" "design-lite" "review-lite")
+# Skills exempt from rule (A). Rule (A) targets skills whose termination
+# contract lives in in-session bash variables (e.g., design-review's
+# `consecutive_no_major` / `INNER_EXIT_REASON`) that post-conversation
+# compaction can summarize away, producing silent mis-termination. All other
+# skills recover termination state from elsewhere and are therefore exempt:
+#   - Multi-round agent-team skills (design / review / design-lite / review-lite
+#     / design-apply) — termination contract lives in `_common/team-cleanup.md`
+#     plus file-recovery slug bindings.
+#   - Single-pass verdict-emit skills (design-ingest) — loop state recovered
+#     from `## Verdict:` headers on disk; every invocation is fresh-context.
+#   - Linear authoring skills (design-system / design-prompt / design-upgrade)
+#     — no loop at all, no termination contract to lose.
+#   - IO orchestrators (active-notify / implement) — termination is a
+#     hook/tool-driven boundary, not a counter the model has to maintain.
+# In effect, the only non-exempt member is the `design-review ↔
+# design-review-lite` pair (which rule B additionally enforces via phrase sync).
+EXEMPT_SKILLS=("active-notify" "design-upgrade" "implement" "design" "review" "design-lite" "review-lite" "design-system" "design-prompt" "design-ingest" "design-apply")
 
 # Resolve skills root (allow SKILLS_ROOT env override for tests).
 script_dir=$(cd "$(dirname "$0")" && pwd)


### PR DESCRIPTION
## Summary

기존 `design → design-review → implement → review` 파이프라인은 markdown 설계 문서 기반 흐름에는 완벽하지만, claude.ai/design은 cc-cmds가 직접 호출할 수 없는 외부 수동 도구이고 산출물(HTML 핸드오프 번들 + `:root` CSS 토큰)을 사람이 가져와 다음 단계로 넘겨야 하기 때문에 단절이 있었다. 본 PR은 그 단절을 메우는 4개 신규 슬래시 스킬과 6개 실측으로 확정된 3-rung 하이브리드 파싱 계약을 구현한 공유 prose 2종을 도입한다.

### 신규 스킬 (4)

- **`design-system`** — DS 워크스페이스 2-phase. phase1은 base 설계+코드베이스에서 DS 방향성 정보를 가변 Q&A 페어(개수·순서 가변, 고정 카테고리 enumerate 금지)로 추출해 사전답변에 포함하고 HANDOFF CONTRACT 블록을 quote하며 relay 루프 안내를 emit. phase2는 incoming/ 번들을 파서로 ingest해 `tokens.css`(authored-css 블록만 + wrapper 보존 + provenance 헤더 + theme 정렬 + dedup) · `tokens.md` · `components.md` · `manifest.json`을 생성.
- **`design-prompt`** — base 설계 문서 `docs/{slug}.md`에 stable anchor로 CD 프롬프트 섹션 in-place authoring(append·중복 금지) + 파생 붙여넣기 블록 `docs/{slug}-fe/cd-prompt.paste.md` 조립. 붙여넣기 블록은 HANDOFF CONTRACT + `tokens.css` byte-verbatim 인용 + 기능 의도 + 산출물 가이드라인 5블록 구조.
- **`design-ingest`** — 번들 파싱 + 단일 에이전트 리뷰(5축: 토큰-vs-DS / a11y 대비비 / 반응형·터치 / base 의도 충실도 / 시각 품질) + ACCEPT/REFINE 파일 복구 루프. 균일 레코드 기반 (a) DS 동봉 drift-diff / (b) `var()` 참조-only 누락 검증 두 패턴 분기. 루프 상태는 `iter-NNN/review.md`의 `## Verdict:` 첫 줄 헤더 + 디렉토리 열거로 매 호출 fresh-context 복구. `ITER_CAP=3` soft cap.
- **`design-apply`** — `design-lite` 패턴 모사 agent-team sibling. 입력 경로 `docs/{slug}-fe/handoff-extract.md`에서 `{slug}`를 파싱해 팀명 `design-apply-{slug}` 조립 + cleanup 복구 키로 사용. concrete-input bootstrap이라 greenfield 인터뷰 생략.

### 공유 prose (2)

- **`_common/handoff-contract.md`** — emitter와 parser가 공유하는 frontmatter 스키마 단일 정의 (`handoff_schema: 1`). non-load-bearing cross-check doctrine.
- **`_common/parse-handoff.md`** — 3-rung 저하(CONTRACT/BEST-EFFORT/AGENT 직독) 추출 메커니즘. MALFORMED는 caller-agnostic 구조 게이트만 한정, 토큰 부재는 `tokens_absent:true`로 caller 결정. 균일 출력 레코드(happy-path · fallback 동형).

### 기타

- `scripts/lint-skill-invariants.sh` — EXEMPT_SKILLS에 신규 4스킬 추가 + 주석을 현재 멤버 전부 포괄하도록 재서술.
- `README.md` — 신규 4스킬 ## Commands 표·## Options 자동 재생성 + `### Claude Design 핸드오프 품질 리뷰 (선택)` 수동 prose 추가. `web-design-guidelines`는 vercel-labs `agent-skills` 리포의 skills-CLI 개별 스킬이라 `plugin.json` `dependencies`로 표현 불가 → graceful degradation + 정확한 설치 명령(`npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines`) 명시. terminal-notifier와 동일 doctrine.
- `CHANGELOG.md` v1.8.0 entry 추가 + `plugin.json` 1.7.0 → 1.8.0 bump.

### Doctrine

번들은 자유 형식이라(6개 실측 확정) frontmatter contract는 opportunistic accelerator로만 쓰고 SAFE 앵커(outer README + "Read X in full" + `project/` + HTML ≥1)와 Agent 직독으로 graceful 저하한다. 토큰 진실값은 README나 frontmatter가 아니라 항상 `:root`(주로 공유 `.css`). 단일 관찰을 frozen 계약으로 박지 않는 doctrine은 CD 방향성 폼 사전답변에도 적용해 가변 Q&A 페어로 추출한다.

## Test plan

- [x] `make lint` 통과 (lint-skill-invariants 13개·lint-skill-options 13개·lint-skill-paths 27개·lint-bash-portability 17개).
- [x] `make readme` 자동 재생성으로 신규 4스킬 SKILLS_TABLE·SKILLS_OPTIONS 추가됨.
- [x] 신규 4스킬 모두 EXEMPT_SKILLS 매칭 + 기존 7개 멤버 그대로 + design-review ↔ design-review-lite 쌍 phrase-sync 유지.
- [ ] E2E: `design-system` phase1 → 외부 실행 → phase2 ingest → `design` → `design-prompt` → `design-review --base` → `design-prompt` 재실행 → `design-ingest` (ACCEPT/REFINE 양쪽) → `design-apply` → `design-review` → `implement` → `review`까지 파일 인계 끊김 없이 이어지는지 (외부 단계 전후 세션 중단 후 디스크 아티팩트만으로 재개 포함).
- [ ] DS 사용 패턴 (a) 번들 DS `.css` 동봉 drift-diff 작동.
- [ ] DS 사용 패턴 (b) `var()`-only `referenced_undefined_vars[]` 검출.
- [ ] MALFORMED (README 부재 / HTML 0개) 즉시 escalate.
- [ ] `tokens_absent`: design-system phase2 차단 / design-ingest var() 검증 path.
- [ ] divergent 토큰: design-system phase2 escalate / design-ingest REFINE-eligible.
- [ ] frontmatter 부재 번들에서 Rung2 fallback 작동.
- [ ] CD 방향성 질문 폼 relay (사전답변 외 질문 시나리오).
- [ ] `ITER_CAP=3` 도달 시 4회차 `AskUserQuestion` 분기.
- [ ] `design-apply` 중단 후 재호출 시 입력 경로 slug → 팀명 cleanup 복구.