### PR TITLE
fix(design-review): 리뷰 라운드 직렬 실행 강제로 로그 날조 차단

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.5] - 2026-06-01
+
+`design-review`와 `design-review-lite`의 inner review loop는 라운드 N+1의 입력이 라운드 N의 적용 출력인 직렬 의존 사슬을 갖는다. 그러나 실행 모델이 한 turn에서 여러 라운드·이터레이션의 리뷰 에이전트를 동시에 spawn하고, **아직 반환되지 않은** 에이전트 결과에 대해 disposition 로그·수렴 판정·`COUNT_APPLIED` 집계를 미리 날조하는 오작동이 관측됐다. 특히 날조된 `clean-convergence` + `COUNT_APPLIED == 0`은 outer 종료 판정에서 도달하지 않은 fixpoint로 전체 리뷰 사이클을 silent early-exit시킨다. 두 스킬의 `## Control-Flow Invariants` 최상단에 advance-ordering(직렬화)·observed-result(anti-fabrication, fail-closed) 불변식 2개를 추가해 하드닝한다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Fixed
+
+- `design-review`/`design-review-lite` SKILL.md의 `## Control-Flow Invariants` intro 직후에 두 불변식 하위 섹션을 추가한다. (1) **Round/iteration advance ordering** — 라운드 경계에서는 라운드 N의 Edit가 디스크에 반영되기 전에 라운드 N+1의 review `Agent()`를 spawn하지 않으며, 이터레이션 경계에서는 iter K의 per-iteration summary가 끝나기 전에 iter K+1의 `INNER_TEMP_DIR`를 초기화하지 않는다(no look-ahead spawn). intra-round 활동(self-triage·batched Edits·AUQ fan-out 등)은 제약하지 않는다. (2) **Observed-result precondition** — 어떤 round-N audit 기록(disposition tag·`COUNT_APPLIED`·convergence verdict·outer_log)도 해당 라운드의 review Agent()가 실제로 반환·관측된 경우에만 작성 가능하며, 불확실하면 fail-closed로 re-spawn 후 작성한다. lite는 auto-decide 미보유라 `[AUTO-DECIDED]`·`escalate_applied`를 제외한 단순화 사본을 inline한다.
+- `scripts/lint-skill-invariants.sh`의 `REQUIRED_PHRASES`에 두 canonical 앵커(`no look-ahead spawn`, `Agent() actually returned`)를 추가해 base↔lite 양쪽 불변식 prose의 존재·동기화를 CI에서 강제한다. 회귀 fixture(`T-INV-OK-1`)에도 동일 앵커를 반영했다.
+
 ## [1.8.4] - 2026-06-01
 
 여러 스킬에서 `AskUserQuestion`(AUQ) 호출 시 `InputValidationError`가 반복 발생하던 문제를 하드닝한다. 레포에서 AUQ를 호출하는 스킬 10개 중 `design`만 AUQ 하드 스키마(12자 header, 옵션 `description` 필수, 옵션 2~4개)에 하드닝돼 있었고, 나머지 스킬과 `design-review` 계열 reference는 옵션을 **bare label 문자열**로 제시하는 템플릿이 모델을 malformed 호출로 직접 유도했다. 근본 원인이 런타임이 아니라 작성된 템플릿(upstream)이므로, 공통 스펙 + 런타임 Read 참조 + 템플릿 in-place 교정 + lint 게이트의 4단 통제를 함께 적용한다 (`/plugin update cc-cmds`로 자동 반영).

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.8.4",
+    "version": "1.8.5",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/design-review-lite/SKILL.md
+++ b/plugins/cc-cmds/skills/design-review-lite/SKILL.md
@@ -25,6 +25,7 @@ in the same change. Sync responsibility:
   - review-agent prompt                                       → Phase 2 Step 12 prompt
   - severity exit policy / 4-tier note                        → Phase 2 Step 14 note
   - Korean UX templates (§3.9.4.a/b/c, §3.9.2, §3.9.4.e)      → Phase 2 Step 16 / Step 24 / Step 25 / Phase 3
+  - CFI advance-ordering + observed-result invariants         → Control-Flow Invariants top subsections
 The phrase-presence rule in `scripts/lint-skill-invariants.sh` enforces sync
 on termination-contract phrases only (CI fail-fast). Other inlined content
 relies on human review.
@@ -52,6 +53,21 @@ Requirement consistency, internal coherence, feasibility, implementation order, 
 ## Control-Flow Invariants
 
 These formulas govern termination and classification. They MUST remain inline (not in a separate file) because SKILL.md has post-compaction re-attachment priority (first ~5K tokens) while a separate file's read may be summarized away. A summarized invariant yields silent mis-termination.
+
+#### Round/iteration advance ordering (no look-ahead spawn)
+
+The inner loop's correctness rests on a happens-before ordering between adjacent rounds and adjacent outer iterations — NOT on any turn count. It binds at exactly two boundaries and nowhere else:
+
+- **Round boundary**: the main session MUST NOT spawn round N+1's review `Agent()` until round N's resulting Edits are on disk. A review agent reads the document on spawn; if round N+1's agent spawns before round N's edits have landed, it reviews stale text and every proposal it returns is grounded in a document state that no longer exists.
+- **Iteration boundary**: the main session MUST NOT initialize iter K+1's `INNER_TEMP_DIR` (Step 7) until iter K's per-iteration summary work (Steps 17–21 — `COUNT_APPLIED`, ack extraction, table/log rows, and the `INNER_TEMP_DIR` wipe) has completed against the agent results actually observed in iter K.
+
+This ordering is scoped to the spawn/init boundary ONLY. It deliberately does NOT constrain intra-round activity: one round may issue many tool calls in a single turn (self-triage, reference Reads, batched auto-approve Edits, AskUserQuestion fan-out), and one round may span multiple turns (the dialogue loop on an escalated proposal runs across several turns, all still inside round N). The "batch independent edits in one message" practice stays fully valid for those intra-round Edits — but it does NOT apply across a round/iteration boundary, because round N+1's input IS round N's applied output and the rounds are therefore not independent units of work. The one forbidden move is forward progress across a boundary on unobserved upstream work: there is no look-ahead spawn — never spawn the next round's agent before this round's edits are on disk, and never open the next iteration before this iteration's summary work is done.
+
+#### Observed-result precondition (anti-fabrication — hard fail-closed gate)
+
+This precondition is independent of the ordering rule above and is NOT waivable under any time, batching, or economy pressure. The main session MUST NOT write any round-N record — disposition tag (`[APPROVED]` / `[MODIFIED]` / `[USER-DIRECTED]` / `[AUTO-APPROVED]` / `[AUTO-REJECTED]` / `[REJECTED]`), `COUNT_APPLIED` input, `INNER_EXIT_REASON == "clean-convergence"` (or any convergence verdict), convergence-table row, ack delta, or `## Outer Iteration N` outer_log entry — unless round N's review Agent() actually returned and that return was observed at some point during round N. The on-disk round-N proposals and round summary are the persisted PRODUCT of that observed return (carrying grounding across turns for deferred dispositions); they are NOT themselves the grounding, and neither may be authored by the main session to manufacture grounding.
+
+Decision procedure before writing any round-N record: "Did I actually spawn round N's agent and observe its return at some point during this round?" If you cannot affirm a real observed return — or you are uncertain — **fail closed**: do not record, do not count, do not declare convergence; instead spawn (or re-spawn) the agent, wait for its real return, then write. Re-spawn is the cheap safe direction (a redundant fresh review only costs tokens; a fabricated record corrupts termination). A convergence verdict or `COUNT_APPLIED` tally is a factual claim that specific agent work happened; writing one for a round whose agent never spawned or never returned is fabrication and is absolutely forbidden. (The deferred-disposition case is explicitly fine: round N's agent really returned and its proposals are on disk; finalizing those dispositions turns later after the user decides is grounded, not fabricated.)
 
 ### Inner convergence predicate
 

--- a/plugins/cc-cmds/skills/design-review/SKILL.md
+++ b/plugins/cc-cmds/skills/design-review/SKILL.md
@@ -54,6 +54,21 @@ Requirement consistency, internal coherence, feasibility, implementation order, 
 
 These formulas govern termination and classification. They MUST remain inline (not in `references/`) because SKILL.md has post-compaction re-attachment priority (first ~5K tokens) while `references/` reads may be summarized away. A summarized invariant yields silent mis-termination.
 
+#### Round/iteration advance ordering (no look-ahead spawn)
+
+The inner loop's correctness rests on a happens-before ordering between adjacent rounds and adjacent outer iterations — NOT on any turn count. It binds at exactly two boundaries and nowhere else:
+
+- **Round boundary**: the main session MUST NOT spawn round N+1's review `Agent()` until round N's resulting Edits are on disk. A review agent reads the document on spawn; if round N+1's agent spawns before round N's edits have landed, it reviews stale text and every proposal it returns is grounded in a document state that no longer exists.
+- **Iteration boundary**: the main session MUST NOT initialize iter K+1's `INNER_TEMP_DIR` (Step 7) until iter K's per-iteration summary work (Steps 17–21 — `COUNT_APPLIED`, ack extraction, table/log rows, and the `INNER_TEMP_DIR` wipe) has completed against the agent results actually observed in iter K.
+
+This ordering is scoped to the spawn/init boundary ONLY. It deliberately does NOT constrain intra-round activity: one round may issue many tool calls in a single turn (self-triage, reference Reads, batched auto-approve Edits, auto-decide, AskUserQuestion fan-out), and one round may span multiple turns (the dialogue loop on an escalated proposal runs across several turns, all still inside round N). The "batch independent edits in one message" practice stays fully valid for those intra-round Edits — but it does NOT apply across a round/iteration boundary, because round N+1's input IS round N's applied output and the rounds are therefore not independent units of work. The one forbidden move is forward progress across a boundary on unobserved upstream work: there is no look-ahead spawn — never spawn the next round's agent before this round's edits are on disk, and never open the next iteration before this iteration's summary work is done.
+
+#### Observed-result precondition (anti-fabrication — hard fail-closed gate)
+
+This precondition is independent of the ordering rule above and is NOT waivable under any time, batching, or economy pressure. The main session MUST NOT write any round-N record — disposition tag (`[APPROVED]` / `[MODIFIED]` / `[USER-DIRECTED]` / `[AUTO-DECIDED]` / `[AUTO-APPROVED]` / `[AUTO-REJECTED]` / `[REJECTED]`), `COUNT_APPLIED` / `escalate_applied` input, `INNER_EXIT_REASON == "clean-convergence"` (or any convergence verdict), convergence-table row, ack delta, or `## Outer Iteration N` outer_log entry — unless round N's review Agent() actually returned and that return was observed at some point during round N. The on-disk round-N proposals and round summary are the persisted PRODUCT of that observed return (carrying grounding across turns for deferred dispositions); they are NOT themselves the grounding, and neither may be authored by the main session to manufacture grounding.
+
+Decision procedure before writing any round-N record: "Did I actually spawn round N's agent and observe its return at some point during this round?" If you cannot affirm a real observed return — or you are uncertain — **fail closed**: do not record, do not count, do not declare convergence; instead spawn (or re-spawn) the agent, wait for its real return, then write. Re-spawn is the cheap safe direction (a redundant fresh review only costs tokens; a fabricated record corrupts termination). A convergence verdict or `COUNT_APPLIED` tally is a factual claim that specific agent work happened; writing one for a round whose agent never spawned or never returned is fabrication and is absolutely forbidden. (The deferred-disposition case is explicitly fine: round N's agent really returned and its proposals are on disk; finalizing those dispositions turns later after the user decides is grounded, not fabricated.)
+
 ### Inner convergence predicate (§3.11)
 
 ```

--- a/scripts/lint-skill-invariants.sh
+++ b/scripts/lint-skill-invariants.sh
@@ -150,6 +150,8 @@ REQUIRED_PHRASES=(
   'INNER_EXIT_REASON == "clean-convergence"'
   'INNER_EXIT_REASON == "safety-limit-fresh-outer"'
   'INNER_EXIT_REASON == "safety-limit-outer-terminate"'
+  'no look-ahead spawn'
+  'Agent() actually returned'
 )
 
 # Extract the Control-Flow Invariants section body of a SKILL.md file.

--- a/tests/fixtures/lint-skill-invariants/T-INV-OK-1/design-review-lite/SKILL.md
+++ b/tests/fixtures/lint-skill-invariants/T-INV-OK-1/design-review-lite/SKILL.md
@@ -18,6 +18,8 @@ inner_converged_cleanly() =
 
 `final_critical_or_major = |{p : p.severity (post-upgrade) ∈ {critical, major}}|`
 
+Advance ordering: there is no look-ahead spawn. Anti-fabrication: write a record only if round N's review Agent() actually returned.
+
 ```
 if INNER_EXIT_REASON == "safety-limit-outer-terminate": break
 elif INNER_EXIT_REASON == "safety-limit-fresh-outer": outer_done = false

--- a/tests/fixtures/lint-skill-invariants/T-INV-OK-1/design-review/SKILL.md
+++ b/tests/fixtures/lint-skill-invariants/T-INV-OK-1/design-review/SKILL.md
@@ -18,6 +18,8 @@ inner_converged_cleanly() =
 
 `final_critical_or_major = |{p : p.severity (post-upgrade) ∈ {critical, major}}|`
 
+Advance ordering: there is no look-ahead spawn. Anti-fabrication: write a record only if round N's review Agent() actually returned.
+
 ```
 if INNER_EXIT_REASON == "safety-limit-outer-terminate": break
 elif INNER_EXIT_REASON == "safety-limit-fresh-outer": outer_done = false


### PR DESCRIPTION
## 배경

`design-review`와 `design-review-lite`의 inner review loop는 라운드 N+1의 입력이 라운드 N의 적용 출력인 직렬 의존 사슬을 갖는다. 각 라운드는 (1) fresh 에이전트가 현재 디스크 문서를 검토 → 제안 작성, (2) main session이 self-triage 후 Edit 적용, (3) 다음 라운드 에이전트가 그 post-edit 문서를 재검토하는 happens-before 순서를 따른다.

## 문제

실행 모델이 한 turn에서 여러 라운드·이터레이션의 리뷰 에이전트를 동시에 spawn하고, **아직 반환되지 않은** 에이전트 결과에 대해 disposition 로그·수렴 판정·`COUNT_APPLIED` 집계를 미리 날조하는 오작동이 관측됐다. 특히 날조된 `clean-convergence` + `COUNT_APPLIED == 0`은 outer 종료 판정에서 도달하지 않은 fixpoint로 전체 리뷰 사이클을 silent early-exit시킨다.

## 변경

prose-only 불변식 2개 + lint phrase-sync로 하드닝한다 (스킬에 hook/helper surface가 없어 self-authored 파일 게이트는 forgeable하므로, 강제 가능한 ceiling은 lint의 phrase-presence 동기화뿐).

- 두 SKILL.md의 `## Control-Flow Invariants` intro 직후에 불변식 2개 추가:
  - **Round/iteration advance ordering** — 라운드 경계에서 라운드 N의 Edit가 디스크에 반영되기 전 라운드 N+1 review `Agent()` spawn 금지, 이터레이션 경계에서 iter K summary 완료 전 iter K+1 `INNER_TEMP_DIR` 초기화 금지(no look-ahead spawn). intra-round 활동은 제약하지 않음.
  - **Observed-result precondition** — 어떤 round-N audit 기록도 해당 라운드 review Agent()가 실제 반환·관측된 경우에만 작성, 불확실 시 fail-closed re-spawn.
- lite는 auto-decide 미보유라 `[AUTO-DECIDED]`·`escalate_applied`를 제외한 단순화 사본을 inline; drift-contract 주석에 신규 sync 항목 등록.
- `scripts/lint-skill-invariants.sh` `REQUIRED_PHRASES`에 canonical 앵커 2개(`no look-ahead spawn`, `Agent() actually returned`) 추가로 base↔lite prose 존재·동기화를 CI 강제. 회귀 fixture에도 반영.
- plugin.json `1.8.5` bump + CHANGELOG `### Fixed` entry.

## 검증

`make check`(lint + readme, exit 0, README diff 없음) · `make test`(전 fixture suite 0 failed) 통과.

Closes #27