### PR TITLE
feat(design-analyze): 제3자 설계 문서 다관점 분석 스킬 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-06-03
+
+타인이 작성한 설계/리팩토링 문서를 원본 수정 없이 다관점으로 분석하는 새 스킬 `design-analyze`를 추가한다. `review`의 에이전트 팀 다관점 엔진을 베이스로 하되 입력이 코드 diff가 아니라 산문 설계 문서이며, `design-review`식 외부/내부 수렴 루프 없이 **단일 패스**로 동작한다. 분석 결과는 사용자가 고른 산출물(분석 보고서·인라인 주석 사본·저자 피드백)로 cwd `docs/analysis/`에 생성되며, 원본 문서와 그 소스 repo 전체는 절대 수정하지 않는다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Added
+
+- **`design-analyze` 스킬** (`/cc-cmds:design-analyze <design-doc-path> [--no-codebase] [--report-only]`): 9단계 워크플로우(Step 0–8) — 소스 감지·scope 확인 → 소스 repo grounding 셋업 → 분석 팀 동적 구성 → 병렬 다관점 분석(에이전트 팀) → 합성·분류 → 읽기 전용 발견 워크스루 → 산출물 선택·렌더 → 후속 토론. 발견은 공유 ID `A-NN`(단조·속성 무관) 정본 스키마로 관리되고, 설계 전용 severity(critical/major/minor)·`[foundational]` 플래그·premise-contradiction severity floor·verdict 래더(채택/조건부/보류/재설계)로 분류된다.
+- **읽기 전용 안전 불변(CFI 5종)**: 원본 문서·소스 repo는 어떤 Edit/Write의 대상도 되지 않으며(hard fail-closed), 모든 출력은 cwd `docs/analysis/`의 새 파일이다. 워크스루→산출물 귀결 순서·anti-fabrication·grounding 정직성·team-cleanup 앵커를 `## Control-Flow Invariants` 최상단에 인라인 배치해 압축 소실로 인한 silent corruption을 차단한다.
+- **코드베이스 grounding**: grounding ON이면 cwd가 아닌 **문서가 속한 소스 repo**(`git rev-parse --show-toplevel`)를 Claude Context MCP로 인덱싱하고, `review`와 동일한 재인덱싱 정책(상태 확인 후 missing/outdated만 재인덱싱)을 따른다. repo 부재·인덱싱 실패·`--no-codebase` 시 doc-only 모드로 graceful degrade하며 `doc-code-gap`·`path:line` 인용을 suppress하고 보고서 헤더에 `분석 모드: 문서 단독`을 스탬프한다.
+- **references/**: 분석가 컨텍스트 패키지(렌즈 풀·체크리스트·읽기 전용 프로토콜), 분석 보고서 템플릿(finding 정본 스키마·severity/카테고리/verdict gloss), 인라인 콜아웃 렌더 스펙, 저자 피드백 템플릿.
+- **lint**: `scripts/lint-skill-invariants.sh`의 EXEMPT 설명 주석에 design-analyze 비-exempt 근거(read-only는 control-flow가 아닌 safety 불변이나 동일 요약-소실 위험으로 first-5K position 보호를 차용; review는 mutation이 없어 면제되지만 design-analyze는 파일 생성+소스 미접촉이라 비면제)를 enumeration과 함께 반영했다. 실행 로직(EXEMPT_SKILLS 배열)은 불변이다.
+
 ## [1.8.5] - 2026-06-01
 
 `design-review`와 `design-review-lite`의 inner review loop는 라운드 N+1의 입력이 라운드 N의 적용 출력인 직렬 의존 사슬을 갖는다. 그러나 실행 모델이 한 turn에서 여러 라운드·이터레이션의 리뷰 에이전트를 동시에 spawn하고, **아직 반환되지 않은** 에이전트 결과에 대해 disposition 로그·수렴 판정·`COUNT_APPLIED` 집계를 미리 날조하는 오작동이 관측됐다. 특히 날조된 `clean-convergence` + `COUNT_APPLIED == 0`은 outer 종료 판정에서 도달하지 않은 fixpoint로 전체 리뷰 사이클을 silent early-exit시킨다. 두 스킬의 `## Control-Flow Invariants` 최상단에 advance-ordering(직렬화)·observed-result(anti-fabrication, fail-closed) 불변식 2개를 추가해 하드닝한다 (`/plugin update cc-cmds`로 자동 반영).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Engineering workflow commands for Claude Code.
 | Command | Description | When to use |
 |---------|-------------|-------------|
 | `/cc-cmds:design` | 에이전트 팀을 활용한 기능 설계 토론 진행 | 사용자가 새 기능 설계/아키텍처 결정/다관점 검토가 필요한 설계 논의를 요청할 때 |
+| `/cc-cmds:design-analyze` | 에이전트 팀을 활용한 제3자 설계 문서 다관점 분석 (읽기 전용) | 타인이 작성한 설계/리팩토링 문서를 원본 수정 없이 다관점으로 분석하고 분석 산출물(보고서/주석본/피드백)을 생성하고자 할 때 |
 | `/cc-cmds:design-apply` | Claude Design (claude.ai/design) 산출물을 타깃 코드베이스에 통합하는 구현 상세 설계를 agent team으로 작성 | design-ingest가 ACCEPT한 핸드오프 추출본을 기반으로 실제 코드베이스에 적용할 구현 상세 설계(impl-design.md)가 필요할 때 |
 | `/cc-cmds:design-ingest` | Claude Design (claude.ai/design) 핸드오프 번들을 파싱·리뷰하고 ACCEPT/REFINE 판정으로 개선 루프 진행 | claude.ai/design 에서 받은 HTML 핸드오프 번들을 검토·수용·재프롬프트할 때 (단일 호출 또는 외부 재실행 사이 반복) |
 | `/cc-cmds:design-lite` | 2인 팀을 활용한 경량 설계 토론 | 깊은 다관점 분석보다 빠른 방향 설정이 우선될 때 (sonnet 단독 합성으로 미묘한 invariant 누락 가능) |
@@ -120,6 +121,7 @@ npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-gu
 <!-- SKILLS_OPTIONS_START -->
 
 - [/cc-cmds:design](#cc-cmdsdesign)
+- [/cc-cmds:design-analyze](#cc-cmdsdesign-analyze)
 - [/cc-cmds:design-apply](#cc-cmdsdesign-apply)
 - [/cc-cmds:design-ingest](#cc-cmdsdesign-ingest)
 - [/cc-cmds:design-lite](#cc-cmdsdesign-lite)
@@ -139,6 +141,16 @@ npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-gu
 | Option | Default | Summary |
 | --- | --- | --- |
 | `<task>` | (required) | 설계 토론을 진행할 작업 주제 (자유형 한국어/영문 텍스트). |
+
+### /cc-cmds:design-analyze
+
+**Usage**: `/cc-cmds:design-analyze <design-doc-path> [--no-codebase] [--report-only]`
+
+| Option | Default | Summary |
+| --- | --- | --- |
+| `<design-doc-path>` | (required) | 분석 대상 제3자 설계 문서 경로 (`.md`). 원본은 절대 수정하지 않음. |
+| `--no-codebase` | off (코드베이스 grounding 활성) | 코드베이스 교차검증 비활성화 — 문서 자체만으로 분석 (doc-only 모드). |
+| `--report-only` | off (산출물 대화형 선택) | Step 7 산출물 선택 대화만 건너뛰고 보고서만 생성. Step 6 워크스루(발견별 검토)는 그대로 유지 — 완전 비대화 아님(산출물 범위 한정 플래그). |
 
 ### /cc-cmds:design-apply
 

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.8.5",
+    "version": "1.9.0",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/design-analyze/SKILL.md
+++ b/plugins/cc-cmds/skills/design-analyze/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: design-analyze
+description: 에이전트 팀을 활용한 제3자 설계 문서 다관점 분석 (읽기 전용)
+when_to_use: 타인이 작성한 설계/리팩토링 문서를 원본 수정 없이 다관점으로 분석하고 분석 산출물(보고서/주석본/피드백)을 생성하고자 할 때
+disable-model-invocation: true
+usage: "/cc-cmds:design-analyze <design-doc-path> [--no-codebase] [--report-only]"
+options:
+    - name: "<design-doc-path>"
+      kind: positional
+      required: true
+      summary: "분석 대상 제3자 설계 문서 경로 (`.md`). 원본은 절대 수정하지 않음."
+    - name: "--no-codebase"
+      kind: flag
+      default: "off (코드베이스 grounding 활성)"
+      summary: "코드베이스 교차검증 비활성화 — 문서 자체만으로 분석 (doc-only 모드)."
+    - name: "--report-only"
+      kind: flag
+      default: "off (산출물 대화형 선택)"
+      summary: "Step 7 산출물 선택 대화만 건너뛰고 보고서만 생성. Step 6 워크스루(발견별 검토)는 그대로 유지 — 완전 비대화 아님(산출물 범위 한정 플래그)."
+---
+
+Analyze a third-party software design/refactoring document with a multi-perspective agent team, then render the analysis into user-selected artifacts.
+All team discussions and inter-agent communication should be in English to optimize token usage.
+User-facing communication and rendered artifacts should be in Korean.
+
+This is a **single-pass** analysis (the `review` agent-team engine adapted to prose design docs), NOT a `design-review`-style external/internal convergence loop. The source document and its entire source repo are **read-only** — every output is a new file under cwd `docs/analysis/`.
+
+## Input
+
+> _Consistency Note: README의 user-facing 요약은 frontmatter `options[]`에서 자동 생성됨. 본 섹션은 runtime-agent 작동 규약이며, 변경 시 frontmatter도 함께 갱신._
+
+`$ARGUMENTS` is the path to a third-party design/refactoring document (`.md`), optionally followed by flags `--no-codebase` (doc-only mode) and/or `--report-only` (skip Step 7 artifact selection, force report-only). The first `.md` token is the document path. See Step 1 for parsing.
+
+## Control-Flow Invariants
+
+These rules govern the read-only safety contract and the walkthrough→artifact ordering, and MUST stay near the top of this file. Post-compaction reattaches only the first ~5K tokens with priority; a summarized-away rule here is a **silent corruption vector** — a later "helpful" turn could Edit the source document or its repo, which this skill must NEVER do. This section borrows rule-(A) position protection (first-5K placement) for a **safety** invariant rather than a control-flow/termination contract; the asymmetry with the EXEMPT sibling `review` is justified because `review` mutates nothing it could corrupt, while `design-analyze` creates files and must leave the source repo untouched.
+
+### CFI-1 — Read-only source (hard fail-closed)
+No `Edit`/`Write` may ever target `<design-doc-path>` or any path inside its source repo directory — **no exceptions**. Every output is a NEW file under cwd `docs/analysis/` (the inline annotated artifact is a *copy*; callouts are written only onto the copy). If a desired action would touch the source, it is forbidden — fail closed, do not "helpfully" edit the original.
+
+### CFI-2 — Walkthrough → artifact ordering (no look-ahead render)
+Findings resolve ONLY into artifact content (confirmed/excluded/amended/미검토), never back into the source. Step 7 selection and rendering MUST NOT begin before the Step 6 walkthrough completes or the user aborts. On abort, unprocessed findings are tagged `미검토(사용자 조기 종료)` and rendered into the artifacts with that flag (transparent, retained) — never silently dropped and never written to the source. No look-ahead rendering before the walkthrough resolves.
+
+### CFI-3 — Observed-result precondition (anti-fabrication)
+Only findings, severities, and grounding claims that an analysis agent **actually returned** may be recorded into artifacts. If a result is uncertain or unobserved, fail closed and re-verify — never fabricate a finding, a `path:line` citation, or a verdict.
+
+### CFI-4 — Grounding honesty
+In doc-only mode (source repo absent / inaccessible / `--no-codebase`), every artifact must state its doc-only scope, and doc-only inferences must NOT be presented as code-verified. `doc-code-gap` findings and `path:line` citations are suppressed in doc-only mode.
+
+### CFI-5 — team-cleanup anchor
+Before any Step 8 follow-up and before any team re-composition, the 5-step shutdown in `${CLAUDE_SKILL_DIR}/../_common/team-cleanup.md` MUST run first (cleanup-anchor doctrine).
+
+## Workflow
+
+### Step 0: Tool Loading
+
+Load deferred tools via ToolSearch before any other step:
+- `ToolSearch("select:AskUserQuestion")` — MUST load before Step 1
+- `ToolSearch("select:TeamCreate")`
+- `ToolSearch("select:SendMessage")`
+- `ToolSearch("select:TeamDelete")`
+
+**Before calling AskUserQuestion, Read `${CLAUDE_SKILL_DIR}/../_common/askuserquestion.md`.** Apply the hard constraints from that file (header ≤12 codepoints, no manual Other option, `preview` single-select only) to every AskUserQuestion call in this skill.
+
+---
+
+### Step 1: Source Detection & Scope Confirmation (Korean)
+
+#### 1a: Argument parsing & source validation
+
+Parse `$ARGUMENTS`:
+- The first `.md` token is `<design-doc-path>`.
+- `--no-codebase` → grounding OFF (doc-only mode).
+- `--report-only` → Step 7 artifact-selection dialog skipped, report forced (Step 6 walkthrough still runs).
+
+Validate the source document:
+1. Path exists and is readable. If not, report the error in Korean and stop (normal error handling — not a CFI concern).
+2. Extension is `.md`. If not, ask the user via AskUserQuestion whether to proceed treating it as markdown, or abort.
+3. **Read the entire document** (parseability gate). If it is unreadable/binary/empty, surface and stop.
+
+#### 1b: Source repo detection
+
+Detect the git repo that **owns the source document** (NOT cwd — usually a different repo, e.g. `~/Documents/orderbook/`):
+
+```bash
+# Never use `git -C`. cd into the document's directory first, then run git.
+DOC_DIR=$(dirname "<design-doc-path>")
+cd "$DOC_DIR"
+CODE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+```
+
+- If `CODE_ROOT` resolves and grounding is ON → Step 2 indexes it.
+- If `CODE_ROOT` is empty (not a repo) → AskUserQuestion fallback: (a) specify a code root path directly via the `Other` channel, (b) doc-only analysis, (c) abort.
+
+#### 1c: Scope confirmation (read-only assurance + artifact-timing pre-notice)
+
+Present to the user (in Korean):
+- Document title, section count, size
+- Detected source repo (`CODE_ROOT` absolute path) or "감지된 repo 없음 → 문서 단독 분석"
+- grounding ON/OFF (and reason: `--no-codebase` / repo 부재 / etc.)
+- **Read-only assurance**: 원본 문서와 소스 repo는 절대 수정하지 않으며, 모든 산출물은 cwd `docs/analysis/`에 새 파일로 생성됨을 고지.
+- **Artifact-timing pre-notice**: "산출물(보고서/주석본/피드백) 선택은 분석·검토 *후* 진행합니다" — do NOT present an artifact-selection prompt here.
+
+**초대형 문서 게이트** (e.g. very long doc / many sections): inform the user of the scale and offer (via AskUserQuestion, header chip `분석 범위`) to limit analysis to a section range vs. analyze the whole document.
+
+Proceed after user confirmation.
+
+---
+
+### Step 2: Codebase Indexing & Grounding Setup
+
+Skip entirely (→ doc-only mode) when grounding is OFF (`--no-codebase`, repo absent, or user chose doc-only).
+
+When grounding is ON and `CODE_ROOT` exists, index the **source repo** (`CODE_ROOT`, not cwd) via Claude Context MCP. **Re-indexing policy is identical to `review` Step 2a** — do NOT unconditionally re-index every run:
+
+1. Check existing index via `get_indexing_status` for `CODE_ROOT`. If current, reuse and proceed.
+2. If index missing or outdated:
+   a. Identify exclusion targets — survey `CODE_ROOT` structure (`ls`), read `CODE_ROOT`'s CLAUDE.md and .gitignore; common exclusions: `node_modules, .next, build, dist, __pycache__, .git, coverage, .turbo, .cache, out, .vercel, .output, vendor, target`.
+   b. Call `index_codebase` with the absolute `CODE_ROOT` path + exclusion list.
+   c. Poll `get_indexing_status` until status = "completed" — **never proceed before indexing completes**.
+
+Analysts use `search_code` directly during Step 4.
+
+**Graceful degrade (CFI-4)**: repo absent / indexing error / user rejection → doc-only mode. Suppress `doc-code-gap` findings and `path:line` citations, emit a Korean notice, and stamp the report header `분석 모드: 문서 단독`. Propagate the doc-only marker to Step 4 analyst packages and Step 5 synthesis.
+
+---
+
+### Step 3: Analysis Team Composition Proposal (Korean)
+
+Propose a team based on two composition signals: (i) the document's own structure (TOC/heading + keyword scan) and (ii) grounding code exploration.
+
+**Default lens pool** (design-doc analog of security/perf/quality):
+
+| Lens | 한글 | 범위 |
+| --- | --- | --- |
+| architecture-soundness | 구조 건전성 | 레이어링·모듈 경계·결합도; 제안 구조가 성립하는가 |
+| feasibility & impl-cost | 실현가능성·구현비용 | 작성된 대로 구현 가능한가; 난이도·숨은 비용 |
+| migration-safety | 마이그레이션안전 | (리팩토링/마이그레이션) 데이터 손실·롤백·단계적 전환·하위호환 |
+| completeness/gaps | 완전성·누락 | 누락 인터페이스·미처리 케이스·미정의 에러/엣지 |
+| internal-consistency | 내부일관성 | 섹션 간 모순·명명/계약 불일치 |
+| alternatives-evaluation | 대안평가 | 옵션 검토 여부·선택 근거 정당성 |
+| doc-vs-code grounding | 문서-코드정합성 | (grounding ON) 문서의 코드 전제가 실제 코드와 일치하는가 |
+
+**Document-characteristic → role triggers** (analog of review's "auth change → security reviewer"):
+- 리팩토링/재작성 → migration-safety (필수) + architecture
+- 신규 레이어링·모듈 → architecture
+- ≥2 옵션·trade-off → alternatives
+- 스키마·데이터모델 → +data-integrity
+- auth·권한 → +security-design
+- API·계약 → +api-contract
+- 성능·스케일 주장 → +scalability
+- 코드 다수 인용 (grounding ON) → doc-vs-code grounding (필수)
+- 대형·다중도메인 (>~15 섹션) → +Analysis Coordinator (persistent, analog of review's Scope Coordinator)
+
+**Model**: not fixed — propose per run with rationale (review Step 3 convention). opus → architecture/alternatives (multi-step reasoning); sonnet → feasibility/migration/consistency/grounding; haiku → mechanical completeness sweep of short docs. Bump one tier up for large/foundational docs.
+
+**Proposal format** (Korean):
+
+```
+**문서 특성 분석:**
+- 문서 유형: [리팩토링/신규 설계/마이그레이션 등]
+- 섹션 수·규모: [N개 섹션, 크기]
+- 핵심 신호: [감지된 특성 — 스키마 변경, auth, 코드 인용 다수 등]
+- 분석 모드: 코드 grounding ON (CODE_ROOT) / 문서 단독
+
+**제안 팀 구성:**
+| 역할(렌즈) | 모델 | 담당 범위 |
+|------------|------|-----------|
+| ... | ... | ... |
+
+**팀 구성 근거:**
+[1-2 문장: 왜 이 구성이 이 문서 특성에 맞는가]
+
+이 팀 구성으로 진행할까요?
+```
+
+Branch on user response: **Approve** → Step 4 / **Modification** → re-propose / **Reject** → end.
+
+---
+
+### Step 4: Parallel Multi-Perspective Analysis (English, team internal)
+
+**Before assigning analysts, Read `${CLAUDE_SKILL_DIR}/../_common/agent-team-protocol.md`** for the completion-signal contract and shared facilitator rules. Include the Teammate Rules block verbatim in each assignment body (do NOT paraphrase — the short form is the documented cause of teammates emitting `[COMPLETE]` as text instead of via SendMessage).
+
+**Before building each analyst's context package, Read `${CLAUDE_SKILL_DIR}/references/01-analyst-context-package.md`** for the context package contents, lens-specific checklists, and the read-only analysis protocol (rounds, quality gate, cross-validation, convergence).
+
+- Create the team with the approved composition. Team naming: `analyze-{doc-slug}` (e.g. `analyze-refactoring`); Step 8 re-composition: original + `-followup`.
+- Each analyst analyzes the prose document from their lens, cross-checks against the indexed code (or operates doc-only), and participates in cross-validation/debate.
+- All team-internal discussion in English.
+- **NO modifications to the source document or source repo (CFI-1). Read-only analysis only.**
+- **The lead acts as facilitator**, actively driving the multi-round analysis. This is a single pass — no external/internal convergence loop.
+
+---
+
+### Step 5: Synthesis & Classification (Korean)
+
+**Before synthesizing, Read `${CLAUDE_SKILL_DIR}/references/02-analysis-report-template.md`** for the finding canonical schema, the design-specific severity/category/verdict system, and the report structure template.
+
+The lead synthesizes all analyst results into the canonical finding set. In this step the lead (and ONLY the lead) assigns the DOWNSTREAM fields:
+- **severity** (critical/major/minor) + **category** taxonomy tag
+- **`[foundational]`** flag — on critical findings only, when the finding topples the document's *core approach* (local fix impossible) → splits 보류 vs 재설계
+- **premise-contradiction severity floor** (doc-code-gap, monotone 3-step): 주변부 모순 → impact 기준(minor 가능) / 리팩토링 *전제* 접촉 → **major floor**(minor 금지) / 핵심 전제·접근 *무효화* → **critical + `[foundational]`** → 재설계. Floor and flag are two thresholds on the same axis (premise proximity); both applied here ("higher severity wins" per review convention).
+- **verdict ladder** (replaces merge recommendation): critical==0 ∧ major==0 → **채택 권고** / critical==0 ∧ major≥1 → **조건부 채택** / critical≥1 ∧ no foundational → **보류** / foundational critical ≥1 → **재설계 권고**.
+
+Anti-fabrication (CFI-3): only record findings the analysts actually returned.
+
+---
+
+### Step 6: Findings Walkthrough (read-only)
+
+Surface findings one at a time to the user and drive each to a disposition that lands in the **확정 발견 집합** (confirmed finding set). The source document and source repo are NEVER modified (CFI-1). The menu has NO team-discussion option — the engine already ran a multi-perspective team; deep re-analysis is Step 8.
+
+#### Walkthrough state (in-memory + scratch persist)
+
+Since the source is untouched, there is no doc-anchored state machine. State = the lead's in-memory **확정 발견 집합**. Working state persists to cwd `docs/analysis/.<slug>.work.json` (NEVER the source). This scratch file is deleted on normal completion (path-guarded `rm` restricted to `docs/analysis/.<slug>.work.json`) and survives ONLY on user abort (audit / manual reference — NOT an auto-resume mechanism; a re-invocation re-runs analysis from scratch). If cwd is a git repo, recommend gitignoring at least `.<slug>.work.json` (or `docs/analysis/`); the report/copy artifacts may be intended commit targets.
+
+**State machine** (2 non-terminal + 4 terminal, memory-anchored):
+```
+pending → presented → { confirmed | excluded | amended }
+            (abort)  → 미검토            # pending|presented → 미검토 on abort
+추가조사: presented → presented            # loop-back, no terminal of its own
+```
+The terminal set {confirmed, excluded, amended, 미검토} equals the §finding-schema `walkthrough_status` enum.
+
+#### 1 finding per AUQ (invariant)
+
+Each `AskUserQuestion` call carries **exactly one finding** (one question). The tool's up-to-4-questions capacity is NEVER used to bundle findings — the only 4-slot budget is the per-finding **option** menu. Each surface includes:
+- a Category/severity chip (e.g. `심각·문서모순`, ≤12 codepoints)
+- Why-it-matters (1–2 lines)
+- 근거 (doc `§anchor` + when grounded `path:line`)
+- the option menu below
+
+#### Menu → 확정집합 effect
+
+| Option | 효과 |
+| --- | --- |
+| 유효(포함) | → `confirmed` |
+| 무효(제외) | → `excluded` (보고서 "검토 후 제외/철회된 항목"에 투명 기록) |
+| 추가조사 | lead read-only 재확인 후 동일 발견 재surface (자체 terminal 없음) |
+| 수정후포함 | → `amended` (보고서 `사용자 수정` 플래그 + `amendment_note`) |
+
+When grounded with strong doc-code-gap evidence, apply `← 추천` to `유효(포함)` (position 1, rationale in its `description` per `_common/askuserquestion.md`).
+
+#### Abort (CFI-2)
+
+The source cannot be batch-marked (it is untouched). On abort, remaining findings are tagged `미검토(사용자 조기 종료)` and kept in the 확정집합 (transparent, non-verified flag) — no silent deletion. Record the abort point in the work-file for audit.
+
+---
+
+### Step 7: Artifact Selection + Rendering
+
+Runs after the walkthrough (the 3 artifacts are variant renders of the same 확정집합 → selection is render-time). Skip the selection AUQ when `--report-only` (force report only; the walkthrough already ran).
+
+**Selection AUQ** (multiSelect): `question: "분석 결과를 어떤 산출물로 생성할까요? (복수 선택 가능)"`, `header: "산출물"`, options:
+- `분석 보고서 ← 추천` (필수 베이스) — description: 모든 발견의 단일 source-of-truth 보고서.
+- `인라인 주석 사본` — description: 원본 복사본에 발견을 콜아웃으로 주석.
+- `저자 피드백 문서` — description: 저자 대상 간결 피드백 목록.
+
+No manual Other (auto-provided). No `preview` (multiSelect).
+
+**report = 필수 베이스 (항상 생성)**: inline/feedback are additive opt-in. 빈 선택 → 보고서; 인라인/피드백 선택 → 보고서 + 해당. report-as-dependency + 빈-선택 가드가 단일 invariant("report always present")로 통합 → `→ 보고서 §… A-NN` ref가 dangling될 수 없음.
+
+**Rendering** — all artifacts under cwd `docs/analysis/`:
+- **Read `${CLAUDE_SKILL_DIR}/references/02-analysis-report-template.md`** → `docs/analysis/<slug>.md` (always).
+- **(if inline) Read `${CLAUDE_SKILL_DIR}/references/03-inline-callout-spec.md`** → `docs/analysis/<slug>.annotated.md` (byte-copy of source + banner + blockquote callouts; source untouched — CFI-1).
+- **(if feedback) Read `${CLAUDE_SKILL_DIR}/references/04-feedback-template.md`** → `docs/analysis/<slug>.feedback.md`.
+
+**Render rule (all artifacts)**: render only `confirmed`/`amended` findings; `excluded` appears ONLY in the report's "철회된 항목" (transparent); `amended` shows its `amendment_note`; `미검토` (abort) is included with its flag. After successful render, delete `.<slug>.work.json` (path-guarded).
+
+---
+
+### Step 8: Discussion & Follow-up (Korean)
+
+After presenting the rendered artifacts, discuss with the user.
+
+- **Lead direct handling** (no team): explain specific findings, re-check code via Claude Context MCP, re-assess severity on new user context, explain exclusions.
+- **Deep re-analysis** (team re-composition): when the user needs perspectives not covered, propose a `analyze-{slug}-followup` team (Step 3 format + re-creation reason + previous coverage + additional scope), require approval, include prior findings in the new package.
+- **`추가조사`** during the walkthrough is lead read-only — it does NOT spawn a team (that would re-introduce a heavy lifecycle); deep work is this step only.
+
+**Before Step 8 follow-up handling AND before any team re-composition, Read `${CLAUDE_SKILL_DIR}/../_common/team-cleanup.md`** and run the 5-step shutdown first (CFI-5). When follow-up triggers team re-composition, always clean up the previous team before creating the next.
+
+Repeat until the user is satisfied.
+
+---
+
+## Constraints
+
+- **Read-only source (CFI-1).** No Edit/Write ever targets `<design-doc-path>` or its source repo. All outputs are new files under cwd `docs/analysis/`.
+- **Inter-agent communication in English.** User-facing communication and rendered artifacts in Korean.
+- **Agent Team required**: Step 4 multi-perspective analysis MUST use TeamCreate and SendMessage. Do NOT substitute Agent tool sub-agents — real-time cross-validation/debate is only possible through Agent Teams.
+- **Deferred tool loading**: Before using AskUserQuestion, TeamCreate, SendMessage, or TeamDelete, load them via ToolSearch in Step 0. AskUserQuestion MUST be loaded before Step 1.
+- **Claude Context MCP**: When grounding is ON, index `CODE_ROOT` (the source repo, not cwd) in Step 2 before team creation. Analysts use `search_code` directly. doc-only mode skips indexing and suppresses code citations (CFI-4).
+- **Single pass**: no `design-review`-style external/internal convergence loop; no termination/COUNT_APPLIED math.
+- **Sequential Thinking MCP**: the lead may use it when synthesizing conflicting analyst findings (Step 5), handling complex follow-up (Step 8), or composing teams for atypical/multi-domain docs (Step 3). Not for routine tasks.
+
+Task: $ARGUMENTS

--- a/plugins/cc-cmds/skills/design-analyze/references/01-analyst-context-package.md
+++ b/plugins/cc-cmds/skills/design-analyze/references/01-analyst-context-package.md
@@ -1,0 +1,59 @@
+# Analyst Context Package
+
+When assigning each analyst (Step 4), include the following in the initial message. All analysis is **read-only** — analysts never modify the source document or source repo (CFI-1).
+
+## Context Package
+
+1. **Completion signal instruction**: Use the `[COMPLETE]` / `[IN PROGRESS]` contract from `_common/agent-team-protocol.md`. Include the **full** instruction block from that file verbatim (delivery channel + message format + self-check every turn + silence-check before stopping) — do NOT paraphrase to a one-liner. The block already uses self-referential "me (the team lead)" phrasing and needs no lead-name substitution.
+2. **The source document**: full text of `<design-doc-path>` (or, for very large docs, the analyst's assigned section range + a TOC of the rest, pointing the analyst to ask for more).
+3. **Assigned lens**: the analyst's role from the Step 3 lens pool + its 범위 (see lens table in SKILL.md Step 3).
+4. **Lens-specific checklist** (see "Lens checklists" below), with MCP `search_code` guidance when grounded.
+5. **Analysis mode**: `grounding ON (CODE_ROOT=<abs path>)` or `doc-only`. In doc-only mode the analyst MUST NOT fabricate code citations and must scope claims to the document only (CFI-3, CFI-4).
+6. **Read-only mandate**: *"You are analyzing a third-party design document. NEVER edit the source document or anything in its source repo. Report findings only."*
+7. **Finding reporting format** (UPSTREAM fields of the canonical schema — see `02-analysis-report-template.md`):
+   ```
+   [severity-hint] [category] §doc-anchor "heading" — <title>
+     code_citations: [path:line, ...]    # grounded only; [] otherwise
+     evidence: why it matters / why this severity
+     suggested_direction: a proposed direction (NOT a forced fix)
+   ```
+   Severity is a *hint*; the lead finalizes severity, `[foundational]`, and verdict in Step 5.
+8. **Category tag list**: `architecture`, `feasibility`, `impl-cost`, `migration-safety`, `completeness`, `consistency`, `alternatives`, `doc-code-gap`, `scalability`, `security-design`, `data-integrity`, `api-contract`.
+9. **Positive findings**: *"If the design makes a notably sound or well-justified choice, note it with a `[POSITIVE]` tag briefly."*
+10. **(Optional) Lead's grounding exploration summary** from Step 2 — key modules the doc references, related code, conventions. Include within context-size limits.
+
+## Lens checklists
+
+**architecture-soundness (구조 건전성):** layering/module boundaries, coupling & cohesion, does the proposed structure actually hold together, hidden circular dependencies, responsibility placement.
+
+**feasibility & impl-cost (실현가능성·구현비용):** can it be built as written, difficulty, hidden cost, unstated prerequisites, sequencing risk, effort vs. stated scope.
+
+**migration-safety (마이그레이션안전):** data loss risk, rollback path, staged transition safety, backward compatibility, dual-write/read windows, irreversible steps. **Required lens for refactoring/migration docs.**
+
+**completeness/gaps (완전성·누락):** missing interfaces, unhandled cases, undefined errors/edges, unspecified contracts, gaps between stated goals and the design.
+
+**internal-consistency (내부일관성):** contradictions between sections, naming/contract mismatches, a decision in §X violated in §Y.
+
+**alternatives-evaluation (대안평가):** were options considered, is the selection rationale justified, unexamined alternatives, false dichotomies.
+
+**doc-vs-code grounding (문서-코드정합성, grounding ON only):** does the document's stated premise about the existing code match reality. 3 sub-modes of `doc-code-gap`: **직접 모순** (doc claims X, code shows not-X), **오독** (doc misreads existing code/behavior), **stale 가정** (doc's premise was true once but the code has since changed). Always cite both sides: the doc claim (`§anchor`) + the actual code (`path:line`).
+
+## Analysis Protocol (read-only, single pass)
+
+1. **Round 1 — Independent analysis**: each analyst analyzes from their lens. Wait for ALL to submit `[COMPLETE]`. On `[IN PROGRESS]`, reply "Take your time and send your complete analysis when ready" — do NOT move on.
+2. **Quality Gate**: before cross-validation, verify each analysis has: specific doc anchors (`§x.y "heading"`) for every finding; when grounded, `path:line` for code claims; severity rationale; checklist coverage (judge by whether items were actually checked, not by finding count — "checked, no issue" is valid). Re-request until QG passes (within the round safety limit).
+3. **Cross-validation**: send each analyst's findings to the others. Request: validate severity hints, identify gaps in overlapping areas, flag false positives, note findings that interact.
+4. **Convergence Check**: use the convergence template from `_common/agent-team-protocol.md`. Only proceed to Step 5 when ALL analysts confirm `[COMPLETE]`. This is a **single pass** — no external/internal convergence loop, no termination math.
+
+## Analysis-specific Facilitator Additions
+
+Beyond the shared facilitator rules in `_common/agent-team-protocol.md`:
+- **Resolve severity disputes**: if analysts disagree, ask each to justify before the lead's Step 5 final call ("higher severity wins" unless resolved).
+- **Premise focus**: for refactoring docs, push analysts to test the document's *premise about the existing code* — that is the highest-value `doc-code-gap` signal.
+- **Round safety limit**: the Step 4 protocol is capped at **10 rounds**. On reaching the limit, report state to the user and ask whether to extend by 10 more.
+
+**When an Analysis Coordinator exists (large/multi-domain doc):**
+- **Round 0**: classify document sections by risk and assign analyst focus areas; included in Round 1 packages.
+- **After Quality Gate**: coverage audit — identify high-risk sections not yet analyzed, request additional analysis.
+- **During cross-validation**: synthesize cross-section issues (inter-module/contract interactions individual analysts miss).
+- Uses the same `[COMPLETE]`/`[IN PROGRESS]` signals; included in Convergence Checks.

--- a/plugins/cc-cmds/skills/design-analyze/references/02-analysis-report-template.md
+++ b/plugins/cc-cmds/skills/design-analyze/references/02-analysis-report-template.md
@@ -1,0 +1,164 @@
+# Analysis Report Template
+
+The lead synthesizes all analysis results into a Korean report using this template (Step 5 → rendered in Step 7). The report is the **required base artifact** — always generated, the single source-of-truth for all findings (inline copy and feedback artifacts reference `→ 보고서 §발견사항 A-NN`).
+
+## Finding canonical schema (single handoff contract)
+
+Analysts produce the UPSTREAM block; the lead appends DOWNSTREAM fields in Steps 5–6. All 3 artifacts render from this object.
+
+```
+Finding {
+  # ── UPSTREAM (analyst-produced) ──
+  id:                 "A-NN"          # monotonic, attribute-independent (stable across severity re-eval)
+  title:              string          # short headline
+  severity:           critical | major | minor
+  category:           <taxonomy tag>  # includes doc-code-gap
+  doc_location:       "§x.y \"heading\""
+  code_citations:     [ "path:line", ... ]   # array; [] when grounding OFF / no code ref
+  evidence:           string          # why it matters / why this severity
+  suggested_direction:string          # proposed direction (NOT a forced fix)
+  analyst_role:       string
+
+  # ── DOWNSTREAM (lead-set ONLY; analysts never set these) ──
+  foundational:       bool            # Step 5 synthesis — on critical only; 보류 vs 재설계
+  walkthrough_status: confirmed | excluded | amended | 미검토   # Step 6 (미검토 = abort)
+  amendment_note?:    string          # Step 6 — only when status == amended
+}
+```
+
+`id = A-NN` is monotonic and **attribute-independent** — it stays stable even if severity is re-evaluated, so every artifact's §ref / callout / feedback item stays aligned.
+
+## Severity system (3 levels)
+
+| Level | Icon | Meaning |
+|-------|------|---------|
+| critical | 🔴 | As written, causes system failure / unsafety / unmaintainability, OR invalidates a core premise |
+| major | 🟠 | Serious gap/risk/cost recommended to resolve before adoption |
+| minor | 🟡 | Improvement, clarification, small gap |
+
+**`[foundational]` flag**: on a `critical` finding when it topples the document's *core approach* (no local fix). Assigned by the lead in Step 5 synthesis. The single axis that splits 보류 vs 재설계.
+
+**premise-contradiction severity floor** (doc-code-gap, monotone 3-step):
+- 주변부 모순 → impact-based (minor allowed)
+- 리팩토링 *전제* 접촉 → **major floor** (minor forbidden)
+- 핵심 전제·접근 *무효화* → **critical + `[foundational]`** → 재설계
+
+Floor and flag are two thresholds on the same axis (premise proximity); both applied in Step 5 ("higher severity wins").
+
+## Category tags
+
+`architecture` · `feasibility` · `impl-cost` · `migration-safety` · `completeness` · `consistency` · `alternatives` · `doc-code-gap` · `scalability` · `security-design` · `data-integrity` · `api-contract`.
+
+**`doc-code-gap`** (한글 라벨 "문서-코드 불일치") = document-vs-code mismatch. 3 sub-modes:
+- **직접 모순**: doc claims X, code shows not-X.
+- **오독**: doc misreads the existing code/behavior.
+- **stale 가정**: doc's premise was true once but the code has since changed.
+
+doc-code-gap findings cite **both sides**: the doc claim (`§anchor`) + the actual code (`path:line`); multiple code locations go in `code_citations[]`.
+
+## Verdict ladder (replaces merge recommendation)
+
+| Condition | Verdict |
+|-----------|---------|
+| critical == 0 ∧ major == 0 | **채택 권고** |
+| critical == 0 ∧ major ≥ 1 | **조건부 채택** (나열된 major 선해소) |
+| critical ≥ 1 ∧ no foundational | **보류** (해당 부분 재작업 후 재평가) |
+| foundational critical ≥ 1 | **재설계 권고** (핵심 전제 불건전) |
+
+Flag-based, not count-threshold: for a third-party design, count thresholds are arbitrary; the real question is whether a critical is locally fixable (보류) or premise-breaking (재설계), which `foundational` captures and audits.
+
+## Render rule
+
+Render only `confirmed` / `amended` findings into the finding sections. `excluded` appears ONLY in "철회된 항목" (transparent). `amended` shows its `amendment_note` with a `사용자 수정` flag. `미검토` (abort) is included with its flag. Empty severity sections are skipped.
+
+## Document structure
+
+File: `docs/analysis/<slug>.md` (create `docs/analysis/` with `mkdir -p` if absent).
+
+```markdown
+# 설계 문서 분석 보고서
+
+## 개요
+
+- **분석 대상**: `<design-doc-path>` — [문서 제목]
+- **분석 날짜**: YYYY-MM-DD
+- **분석 모드**: 코드 grounding (CODE_ROOT: `<absolute path>`) / 문서 단독
+- **분석 범위/커버리지**: [전체 / 섹션 범위; 미분석 영역 요약]
+- **분석 팀 구성**: [역할(렌즈) (모델): 담당 범위 …]
+- **종합 권고 (verdict)**: 채택 권고 / 조건부 채택 / 보류 / 재설계 권고
+- **발견 요약**: 🔴 critical N건 (foundational M건) | 🟠 major N건 | 🟡 minor N건
+
+---
+
+## 종합 권고
+
+[verdict + 1-paragraph rationale. foundational critical이 있으면 재설계 사유를 명시.]
+
+## 핵심 요약
+
+[3-5 문장: 설계의 전반적 건전성, 가장 중요한 발견, 채택 가능성.]
+
+## 방법론
+
+[단일 패스 다관점 팀 분석; 분석 모드; 렌즈별 커버리지.]
+
+---
+
+## 발견 사항
+
+### 🔴 critical ← skip section if none
+
+- **[A-NN · category]** <title> — analyst_role  `[foundational]`(해당 시)
+    - **문서 위치**: §x.y "heading"
+    - **코드 인용**: `path:line` (grounded; doc-code-gap은 문서 주장 §anchor + 실제 코드 path:line 양측)
+    - **근거**: evidence
+    - 💡 제안 방향: suggested_direction
+    - (amended 시) ✏️ **사용자 수정**: amendment_note
+
+### 🟠 major ← skip if none
+…(동일 블록 구조)
+
+### 🟡 minor ← skip if none
+…
+
+---
+
+## 문서-코드 불일치 ← grounding 전용; doc-only 모드에서는 섹션 자체 생략
+
+[doc-code-gap 발견을 sub-mode(직접 모순/오독/stale 가정)별로 묶어 양측 인용과 함께.]
+
+## 대안 평가 요약
+
+[문서가 검토한/누락한 대안, 선택 근거 평가.]
+
+## 긍정적 평가
+
+[설계의 건전한 선택 — analyst `[POSITIVE]` 종합.]
+
+## 미분석 영역
+
+[의도적으로 분석하지 않은 섹션/관점 — blind spot 투명 고지. 워크스루 중단 시 `미검토` 발견도 여기 또는 해당 severity 섹션에 플래그와 함께.]
+
+## 분석가 간 이견
+
+[severity 이견, 양측 근거, 최종 판정.]
+
+---
+
+## 개정 이력
+
+[Step 8 후속에서 변경 발생 시. 초기 생성 시 비움.]
+
+## 철회된 항목
+
+[워크스루에서 `무효(제외)` 처분된 발견 — 투명 기록. 초기엔 비움.]
+- ~~[A-NN 원 발견]~~ — 제외 사유: [사용자 제공 맥락]
+```
+
+## File naming
+
+- Report: `docs/analysis/<slug>.md`
+- Inline copy: `docs/analysis/<slug>.annotated.md` (see `03-inline-callout-spec.md`)
+- Feedback: `docs/analysis/<slug>.feedback.md` (see `04-feedback-template.md`)
+
+`<slug>` derives from the source document filename (e.g. `refactoring.md` → `refactoring`).

--- a/plugins/cc-cmds/skills/design-analyze/references/03-inline-callout-spec.md
+++ b/plugins/cc-cmds/skills/design-analyze/references/03-inline-callout-spec.md
@@ -1,0 +1,38 @@
+# Inline Annotated Copy — Render Spec
+
+Renders `docs/analysis/<slug>.annotated.md`: a **byte-for-byte copy** of the source document with analysis callouts inserted. The source document and its repo are NEVER touched (CFI-1) — callouts live only on this copy under cwd `docs/analysis/`.
+
+## Procedure
+
+1. **Byte-copy the source** into `docs/analysis/<slug>.annotated.md`:
+   ```bash
+   mkdir -p docs/analysis
+   cp "<design-doc-path>" "docs/analysis/<slug>.annotated.md"
+   ```
+   (The original byte content is preserved exactly; only the copy is edited afterward.)
+2. **Prepend a top banner** recording provenance and mode:
+   ```markdown
+   > 📋 **분석 주석 사본** — 원본: `<design-doc-path>`
+   > 분석 모드: 코드 grounding (CODE_ROOT: `<abs path>`) / 문서 단독
+   > 본 파일은 원본의 사본입니다. 콜아웃은 사본에만 추가되며 원본은 수정되지 않았습니다.
+   > 전체 발견·근거는 보고서(`<slug>.md`) 참조.
+
+   ---
+   ```
+3. **Insert a blockquote callout immediately after the relevant block** (the heading/paragraph the finding's `doc_location` points to), for each `confirmed` / `amended` finding:
+   ```markdown
+   > 🟠 **[A-03 · major · 문서-코드 불일치]** <짧은 요지> → 보고서 §발견사항 A-03
+   ```
+   - Icon matches severity: 🔴 critical / 🟠 major / 🟡 minor.
+   - The bracket carries `[A-NN · <severity> · <한글 카테고리 라벨>]`.
+   - Append `[foundational]` inside the bracket when set.
+   - The trailing `→ 보고서 §발견사항 A-NN` keeps the copy aligned to the report's single source-of-truth (A-NN is attribute-stable).
+   - For `amended` findings, append ` (사용자 수정)`.
+
+## Render rule
+
+- Only `confirmed` / `amended` findings get callouts.
+- `excluded` findings are NOT annotated here (they appear only in the report's "철회된 항목").
+- `미검토` (abort) findings: include the callout with a `미검토` marker, e.g. `> ⏸️ **[A-07 · 미검토 · …]** …(사용자 조기 종료로 미검토) → 보고서 …`.
+- In doc-only mode, callouts carry no `path:line`; doc-code-gap callouts are absent (suppressed).
+- Multiple findings on the same block stack as consecutive blockquote lines in A-NN order.

--- a/plugins/cc-cmds/skills/design-analyze/references/04-feedback-template.md
+++ b/plugins/cc-cmds/skills/design-analyze/references/04-feedback-template.md
@@ -1,0 +1,48 @@
+# Author Feedback Document — Template
+
+Renders `docs/analysis/<slug>.feedback.md`: a concise, author-facing list of the analysis findings. Written for the document's author — terse, actionable, grouped by severity. The full rationale lives in the report; this is the hand-off summary.
+
+## Render rule
+
+- Only `confirmed` / `amended` findings.
+- `excluded` findings are omitted.
+- `미검토` (abort) findings are listed under a "미검토 (사용자 조기 종료)" group with their flag.
+- Each item: 이슈 → 근거 → 제안, kept to 1–3 lines. A-NN ties each item back to the report.
+- In doc-only mode, omit code citations and add the doc-only scope note in the header.
+
+## Structure
+
+```markdown
+# 설계 문서 피드백
+
+> 대상: `<design-doc-path>` ([문서 제목])
+> 분석 모드: 코드 grounding / 문서 단독
+> 종합 권고: [verdict]
+> 전체 근거·맥락은 분석 보고서(`<slug>.md`) 참조.
+
+---
+
+## 🔴 우선 해결 (critical) ← skip if none
+
+### [A-NN] <title> `[foundational]`(해당 시)
+- **이슈**: <한 줄 요지> (§doc-anchor)
+- **근거**: <evidence 요약> (grounded: `path:line`)
+- **제안**: <suggested_direction>
+
+## 🟠 채택 전 검토 (major) ← skip if none
+
+### [A-NN] <title>
+- **이슈**: … (§anchor)
+- **근거**: …
+- **제안**: …
+
+## 🟡 개선 제안 (minor) ← skip if none
+
+- **[A-NN]** <title> — <한 줄 이슈+제안> (§anchor)
+
+---
+
+## 미검토 (사용자 조기 종료) ← 워크스루 중단 시에만
+
+- **[A-NN]** <title> — 미검토 상태로 남음 (§anchor)
+```

--- a/scripts/lint-skill-invariants.sh
+++ b/scripts/lint-skill-invariants.sh
@@ -51,8 +51,15 @@ INVARIANT_HEADING='^## Control-Flow Invariants[[:space:]]*$'
 #   - IO orchestrators (active-notify / implement) — termination is a
 #     hook/tool-driven boundary, not a counter the model has to maintain.
 # In effect, the non-exempt members are the `design-review ↔ design-review-lite`
-# pair (which rule B additionally enforces via phrase sync) plus `design` (whose
-# phase-transition invariants live in its top `## Control-Flow Invariants`).
+# pair (which rule B additionally enforces via phrase sync), `design` (whose
+# phase-transition invariants live in its top `## Control-Flow Invariants`), and
+# `design-analyze`. The last is a special case: its load-bearing invariant
+# (read-only source) is a *safety* invariant, not a control-flow/termination
+# contract, yet it borrows rule (A)'s first-5K position protection for the same
+# summarize-away reason — unlike the EXEMPT `review` (which mutates nothing it
+# could corrupt), `design-analyze` creates files while its source repo must stay
+# untouched, so a summarized-away read-only rule is a real silent-corruption
+# vector that first-5K placement guards against.
 EXEMPT_SKILLS=("active-notify" "design-upgrade" "implement" "review" "design-lite" "review-lite" "design-system" "design-prompt" "design-ingest" "design-apply")
 
 # Resolve skills root (allow SKILLS_ROOT env override for tests).


### PR DESCRIPTION
## 개요

타인이 작성한 설계/리팩토링 문서를 **원본 수정 없이** 다관점으로 분석하고, 사용자가 고른 산출물(분석 보고서·인라인 주석 사본·저자 피드백)을 생성하는 새 스킬 `design-analyze`를 추가합니다.

`/cc-cmds:design-analyze <design-doc-path> [--no-codebase] [--report-only]`

## 동작

- `review`의 에이전트 팀 다관점 엔진을 베이스로 하되, 입력이 코드 diff가 아니라 산문 설계 문서이며 외부/내부 수렴 루프 없는 **단일 패스**로 동작합니다.
- 9단계 워크플로우(Step 0–8): 소스 감지·scope 확인 → 소스 repo grounding 셋업 → 분석 팀 동적 구성 → 병렬 다관점 분석 → 합성·분류 → 읽기 전용 발견 워크스루 → 산출물 선택·렌더 → 후속 토론.
- 발견은 공유 ID `A-NN`(단조·속성 무관) 정본 스키마로 관리하고, 설계 전용 severity(critical/major/minor)·`[foundational]` 플래그·premise-contradiction severity floor·verdict 래더(채택/조건부/보류/재설계)로 분류합니다.

## 읽기 전용 안전 보장

원본 문서와 그 소스 repo 전체는 어떤 Edit/Write의 대상도 되지 않으며(hard fail-closed), 모든 출력은 cwd `docs/analysis/`의 새 파일입니다. 압축 소실로 인한 silent corruption을 막기 위해 읽기 전용 등 5개 안전 불변을 `## Control-Flow Invariants` 섹션에 최상단 인라인 배치했습니다.

## grounding

grounding ON이면 cwd가 아니라 **문서가 속한 소스 repo**(`git rev-parse --show-toplevel`)를 Claude Context MCP로 인덱싱합니다(`review`와 동일 재인덱싱 정책). repo 부재·인덱싱 실패·`--no-codebase` 시 doc-only 모드로 graceful degrade하며 `doc-code-gap`·`path:line` 인용을 suppress하고 보고서 헤더에 `분석 모드: 문서 단독`을 스탬프합니다.

## 그 외

- `references/`: 분석가 컨텍스트 패키지·보고서 템플릿·인라인 콜아웃 스펙·피드백 템플릿.
- `scripts/lint-skill-invariants.sh`의 EXEMPT 설명 주석에 design-analyze 비-exempt 근거를 반영했습니다(실행 로직 불변).
- plugin.json `1.8.5` → `1.9.0`(minor) + CHANGELOG entry.

## 검증

- `make check` 통과 (lint + README 재생성 + diff 게이트).
- `make test` 통과 (전체 fixture 회귀).