### PR TITLE
feat(design-review): --changes 플래그 + 사용자 참고 노트 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-06-04
+
+`design-review`와 `design-review-lite`에 "이미 리뷰된 문서에 수정이 발생했을 때 그 수정 사항의 정합성을 검증"하는 사용 패턴을 옵션화한 `--changes` 플래그를 추가한다. 지금까지는 매번 `design-review <doc> 수정 사항 관련 정합성 검증`처럼 자연어 의도를 덧붙여 호출해야 했던 흐름을 재현 가능한 플래그로 만든다. `--changes`는 기존 `--base`와 구조적으로 완전히 동형인 **프롬프트 주입 플래그**다 — git diff·스냅샷 같은 기계적 변경 식별 메커니즘은 도입하지 않고, 플래그가 켜지면 리뷰 에이전트 프롬프트에 `CHANGES MODE CONSTRAINT` 블록을 주입해 에이전트가 능동적으로 무엇이 바뀌었는지 판단한다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Added
+
+- **`--changes` 플래그** (`design-review`·`design-review-lite` 양쪽): 리뷰 초점을 변경분 + 그 파급 반경으로 좁히는 리다이렉트. 두 갈래로 검증한다 — (a) 파급 정합성(각 변경이 데이터 모델·API 계약·시퀀스 흐름·요구사항 추적·구현 순서 등 문서 나머지와 여전히 일치하는지), (b) 변경 자체의 재질의(변경됐다는 이유로 옳다고 가정하지 않고 타당성·완결성·실현가능성을 신규 설계 결정처럼 재검토). `--base`와 직교하며 조합 가능(`--base --changes`) — `--base`는 *허용되는 제안의 종류*를 제약하는 필터, `--changes`는 *리뷰의 초점/대상*을 바꾸는 리다이렉트다. 조합 시 reconcile 불릿이 `"If a BASE MODE CONSTRAINT also appears above…"` 문장으로 자체 활성화되어 base의 제안-종류 제약을 준수하므로 4-way 분기 로직이 불필요하다.
+- **사용자 참고 노트(범용 위치 인자)**: doc-path 뒤 trailing 자유텍스트를 `{USER_NOTE}` 블록으로 주입한다. `--changes` 유무와 무관하게 비어있지 않으면 항상 주입되며, `--changes`가 켜지면 "무엇이 바뀌었는지"의 권위 있는 변경 초점이 되고, 꺼져 있으면 일반 리뷰 참고/초점 컨텍스트로 전달된다. 추출은 `ARGS_CLEAN`에서 토큰 1(doc-path)을 비우고 나머지를 출력하는 무조건 실행으로, 노트가 없으면 빈 문자열이다.
+- **단일-레벨 치환 계약**: `{USER_NOTE}`/`{BASE_MODE_CONSTRAINT}`/`{CHANGES_MODE_CONSTRAINT}` 세 플레이스홀더를 각각 독립적으로 단일 레벨 치환한다(중첩 토큰 없음 — 모델이 2차 해소를 잊어 리터럴 토큰을 누출하는 drift 실패 모드 차단). 프롬프트 본문 배치 순서는 위에서부터 `{USER_NOTE}` → `{BASE_MODE_CONSTRAINT}` → `{CHANGES_MODE_CONSTRAINT}`(각 사이 빈 줄 1개)로, CHANGES 블록의 "if a user-provided note appears above"가 성립하도록 노트가 위에 온다. `outer_log.md` 헤더에 `CHANGES_MODE`·`USER_NOTE`를 무조건 기록해 `BASE_MODE`와 audit provenance 패리티를 맞춘다.
+
+### Why
+
+`--changes`는 신규 disposition 태그를 도입하지 않으므로 종료 수학(`COUNT_APPLIED`/`escalate_applied`/`inner_converged_cleanly()`)·Self-Triage·severity·auto-decide 펜스에 변경이 없다. auto-decide는 main-session 전용이고 리뷰 에이전트에 전파되지 않으므로 에이전트-프롬프트 주입인 `--changes`와 동일 레이어를 건드리지 않는다. inferred 모드(자유텍스트 노트 없이 `--changes`만)의 변경 탐지는 diff·스냅샷 없이 문서만 보고 휴리스틱하게 재구성하므로 본질적으로 부분적이며, 이는 수용된 설계 트레이드오프다 — 완화책은 자유텍스트 설명을 넘겨 hard focus signal로 격상하는 것이다.
+
 ## [1.9.0] - 2026-06-03
 
 타인이 작성한 설계/리팩토링 문서를 원본 수정 없이 다관점으로 분석하는 새 스킬 `design-analyze`를 추가한다. `review`의 에이전트 팀 다관점 엔진을 베이스로 하되 입력이 코드 diff가 아니라 산문 설계 문서이며, `design-review`식 외부/내부 수렴 루프 없이 **단일 패스**로 동작한다. 분석 결과는 사용자가 고른 산출물(분석 보고서·인라인 주석 사본·저자 피드백)로 cwd `docs/analysis/`에 생성되며, 원본 문서와 그 소스 repo 전체는 절대 수정하지 않는다 (`/plugin update cc-cmds`로 자동 반영).

--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-gu
 
 ### /cc-cmds:design-review
 
-**Usage**: `/cc-cmds:design-review <design-doc-path> [--base] [--no-auto-decide-dominant]`
+**Usage**: `/cc-cmds:design-review <design-doc-path> [--base] [--changes] [--no-auto-decide-dominant]`
 
 | Option | Default | Summary |
 | --- | --- | --- |
 | `<design-doc-path>` | (required) | 리뷰 대상 설계 문서 경로 (`.md`) |
 | `--base` | off | 기존 내용 일관성만 검증; 신규 구현 세부 제안 금지 (BASE MODE CONSTRAINT) |
+| `--changes` | off | 이미 리뷰된 문서의 수정 사항으로 리뷰 초점 이동: 파급 정합성 + 변경 자체 재질의 (CHANGES MODE CONSTRAINT). `--base`와 직교·조합 가능 |
 | `--auto-decide-dominant` | _(no-op alias — auto-decide는 기본 ON)_ | 명시적 opt-in 별칭. 현재 기본값이 이미 ON이라 실질 no-op; 역호환·명시성 목적으로 허용. |
 | `--no-auto-decide-dominant` | off (즉, auto-decide 활성) | Decision Auto-Select Protocol(§8)을 세션 전체에서 비활성화 |
 
@@ -207,12 +208,13 @@ npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-gu
 
 ### /cc-cmds:design-review-lite
 
-**Usage**: `/cc-cmds:design-review-lite <design-doc-path> [--base]`
+**Usage**: `/cc-cmds:design-review-lite <design-doc-path> [--base] [--changes]`
 
 | Option | Default | Summary |
 | --- | --- | --- |
 | `<design-doc-path>` | (required) | 리뷰 대상 설계 문서 경로 (`.md`) |
 | `--base` | off | 기존 내용 일관성만 검증; 신규 구현 세부 제안 금지 (BASE MODE CONSTRAINT) |
+| `--changes` | off | 이미 리뷰된 문서의 수정 사항으로 리뷰 초점 이동: 파급 정합성 + 변경 자체 재질의 (CHANGES MODE CONSTRAINT). `--base`와 직교·조합 가능 |
 
 ### /cc-cmds:design-system
 

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/design-review-lite/SKILL.md
+++ b/plugins/cc-cmds/skills/design-review-lite/SKILL.md
@@ -3,7 +3,7 @@ name: design-review-lite
 description: 설계 문서 경량 사이클 리뷰
 when_to_use: 설계 문서를 간결한 반복 사이클로 빠르게 검증하고 싶을 때 (미묘한 termination invariant·동시성 검출률 약화 가능)
 disable-model-invocation: true
-usage: "/cc-cmds:design-review-lite <design-doc-path> [--base]"
+usage: "/cc-cmds:design-review-lite <design-doc-path> [--base] [--changes]"
 options:
     - name: "<design-doc-path>"
       kind: positional
@@ -13,6 +13,10 @@ options:
       kind: flag
       default: "off"
       summary: "기존 내용 일관성만 검증; 신규 구현 세부 제안 금지 (BASE MODE CONSTRAINT)"
+    - name: "--changes"
+      kind: flag
+      default: "off"
+      summary: "이미 리뷰된 문서의 수정 사항으로 리뷰 초점 이동: 파급 정합성 + 변경 자체 재질의 (CHANGES MODE CONSTRAINT). `--base`와 직교·조합 가능"
 ---
 
 <!--
@@ -26,6 +30,7 @@ in the same change. Sync responsibility:
   - severity exit policy / 4-tier note                        → Phase 2 Step 14 note
   - Korean UX templates (§3.9.4.a/b/c, §3.9.2, §3.9.4.e)      → Phase 2 Step 16 / Step 24 / Step 25 / Phase 3
   - CFI advance-ordering + observed-result invariants         → Control-Flow Invariants top subsections
+  - Options blocks (### --base / ### --changes mode-constraint text) → ## Options section
 The phrase-presence rule in `scripts/lint-skill-invariants.sh` enforces sync
 on termination-contract phrases only (CI fail-fast). Other inlined content
 relies on human review.
@@ -163,14 +168,21 @@ COMMAND_NAME="design-review-lite-outer"
 
 # Strip --base from arguments
 ARGS_CLEAN=$(echo "$ARGUMENTS" | awk '{
-  for(i=1;i<=NF;i++) if($i!="--base") printf "%s%s", $i, (i<NF?" ":"")
+  for(i=1;i<=NF;i++) if($i!="--base" && $i!="--changes") printf "%s%s", $i, (i<NF?" ":"")
 }')
 
-# Detect --base
+# Detect --base / --changes
 BASE_MODE=false
+CHANGES_MODE=false
 for arg in $ARGUMENTS; do
   [ "$arg" = "--base" ] && BASE_MODE=true
+  [ "$arg" = "--changes" ] && CHANGES_MODE=true
 done
+
+# USER_NOTE extraction (trailing free-text after doc-path token 1; positional, not a flag).
+# Blank token 1 (doc-path) and print the rest. Always run; empty when no trailing note.
+# Injected as {USER_NOTE} regardless of --changes: change focus when --changes, general review context otherwise.
+USER_NOTE=$(echo "$ARGS_CLEAN" | awk '{$1=""; sub(/^ +/,""); print}')
 
 # REPO_NAME extraction (document stem → repo basename → cwd basename)
 REPO_NAME=$(echo "$ARGS_CLEAN" | awk '{print $1}' | xargs basename 2>/dev/null)
@@ -200,6 +212,8 @@ Session: ${OUTER_SESSION_ID}
 Document: $(echo "$ARGS_CLEAN" | awk '{print $1}')
 Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 BASE_MODE: ${BASE_MODE}
+CHANGES_MODE: ${CHANGES_MODE}
+USER_NOTE: ${USER_NOTE}
 -->
 EOF
 
@@ -318,7 +332,11 @@ Perform agent-based iterative review until severity saturation. Each round spawn
 
 **Step 12** — `inner_round += 1`. Spawn a review agent **with model `"sonnet"`** (lite contract — no haiku, no opus).
 
-**Substitution contract**: `{TEMP_DIR}` → actual `INNER_TEMP_DIR` value; `{BASE_MODE_CONSTRAINT}` → the `--base` BASE MODE CONSTRAINT block (when `BASE_MODE=true`) or a single empty line (when `BASE_MODE=false`).
+**Substitution contract** (each placeholder substituted independently at a single level — no nested tokens; body order top-to-bottom is `{USER_NOTE}` → `{BASE_MODE_CONSTRAINT}` → `{CHANGES_MODE_CONSTRAINT}` so the CHANGES block's "note appears above" holds):
+- `{TEMP_DIR}` → actual `INNER_TEMP_DIR` value.
+- `{USER_NOTE}` → when `USER_NOTE` is non-empty, the single line `USER-PROVIDED NOTE (focus/context for this review): <USER_NOTE>`; when empty, a single empty line. (Mode-independent, always evaluated.)
+- `{BASE_MODE_CONSTRAINT}` → the `--base` BASE MODE CONSTRAINT block (when `BASE_MODE=true`) or a single empty line (when `BASE_MODE=false`).
+- `{CHANGES_MODE_CONSTRAINT}` → the `--changes` CHANGES MODE CONSTRAINT block (when `CHANGES_MODE=true`, static — no nested token) or a single empty line (when `CHANGES_MODE=false`).
 
 Prepend this path-context block before the prompt body:
 
@@ -352,7 +370,11 @@ Then read the design document and review it against ALL of the following criteri
 5. Missing items — Look for gaps: error handling not specified, edge cases not covered, security considerations absent, migration plans missing, rollback strategies undefined.
 6. Contextual review — Based on the specific domain and nature of this design, check for additional concerns that matter in this context but are not covered by the above categories.
 
+{USER_NOTE}
+
 {BASE_MODE_CONSTRAINT}
+
+{CHANGES_MODE_CONSTRAINT}
 
 IMPORTANT: Do NOT modify the design document directly. For every issue found, create a proposal in the following format:
 
@@ -797,7 +819,23 @@ Verify consistency and completeness of the existing design content. Do NOT propo
 - DON'T propose: removing or reducing existing detailed design content.
 ```
 
-When `--base` is not present, remove the `{BASE_MODE_CONSTRAINT}` placeholder line from the agent prompt.
+When `--base` is not present, remove the `{BASE_MODE_CONSTRAINT}` placeholder line from the agent prompt. (LLM-equivalent to substituting a single empty line, as the Step 12 substitution contract phrases it.)
+
+### --changes
+
+Changes-consistency review mode. Orthogonal to `--base` and combinable with it (`--base --changes`): `--base` constrains the KIND of proposals allowed, `--changes` redirects the FOCUS/target of the review onto the modified material and its blast radius. When `$ARGUMENTS` contains `--changes`, substitute the following block for `{CHANGES_MODE_CONSTRAINT}` in the review agent prompt:
+
+```
+CHANGES MODE CONSTRAINT:
+This design document was already reviewed once; your job this round is to review the MODIFICATIONS made to it since then — for consistency with the rest of the document and for soundness in their own right. Actively judge what changed.
+- DO identify the changed material yourself: if a user-provided note appears above, treat it as the authoritative focus for what changed; otherwise infer the recently-modified or suspect sections from the document itself (newer or out-of-place phrasing, additions the surrounding sections have not caught up to, passages that now sit inconsistently against the rest).
+- DO verify ripple consistency: for each change, check that the rest of the document still agrees with it — data models, API contracts, sequence flows, requirement traces, and implementation order that reference or depend on the changed material must remain mutually consistent. Flag any section the change has left stale or contradictory.
+- DO re-question the changes themselves: do not assume a change is correct merely because it was made. Re-examine each change for soundness, completeness, and feasibility on its own terms, exactly as you would scrutinize a fresh design decision.
+- DON'T expend the round re-reviewing unchanged material the changes neither touch nor affect; concentrate effort on the changed material and its blast radius.
+- If a BASE MODE CONSTRAINT also appears above, it remains authoritative on the KIND of proposals you may emit: re-questioning a change must still respect it — surface inconsistencies, contradictions, and essential consistency supplements, but do NOT treat "re-questioning" as license to propose new task-level implementation detail or to remove/reduce existing detailed content. --base governs what kinds of findings are allowed; this block governs where you focus.
+```
+
+When `--changes` is not present, substitute the `{CHANGES_MODE_CONSTRAINT}` placeholder with a single empty line. The reconcile bullet self-activates via its `"If a BASE MODE CONSTRAINT also appears above…"` wording, so no 4-way branch logic is needed — it is naturally inert when no BASE block precedes it.
 
 ## Constraints
 

--- a/plugins/cc-cmds/skills/design-review/SKILL.md
+++ b/plugins/cc-cmds/skills/design-review/SKILL.md
@@ -3,7 +3,7 @@ name: design-review
 description: 설계 문서 최종 리뷰
 when_to_use: 작성된 설계 문서를 다중 반복 에이전트 리뷰(외부/내부 사이클)로 최종 검증·수렴시키고자 할 때
 disable-model-invocation: true
-usage: "/cc-cmds:design-review <design-doc-path> [--base] [--no-auto-decide-dominant]"
+usage: "/cc-cmds:design-review <design-doc-path> [--base] [--changes] [--no-auto-decide-dominant]"
 options:
     - name: "<design-doc-path>"
       kind: positional
@@ -13,6 +13,10 @@ options:
       kind: flag
       default: "off"
       summary: "기존 내용 일관성만 검증; 신규 구현 세부 제안 금지 (BASE MODE CONSTRAINT)"
+    - name: "--changes"
+      kind: flag
+      default: "off"
+      summary: "이미 리뷰된 문서의 수정 사항으로 리뷰 초점 이동: 파급 정합성 + 변경 자체 재질의 (CHANGES MODE CONSTRAINT). `--base`와 직교·조합 가능"
     - name: "--auto-decide-dominant"
       kind: flag
       noop: true
@@ -194,7 +198,7 @@ COMMAND_NAME="design-review-outer"
 
 # 2. Strip flags from arguments
 ARGS_CLEAN=$(echo "$ARGUMENTS" | awk '{
-  for(i=1;i<=NF;i++) if($i!="--base" && $i!="--auto-decide-dominant" && $i!="--no-auto-decide-dominant") printf "%s%s", $i, (i<NF?" ":"")
+  for(i=1;i<=NF;i++) if($i!="--base" && $i!="--changes" && $i!="--auto-decide-dominant" && $i!="--no-auto-decide-dominant") printf "%s%s", $i, (i<NF?" ":"")
 }')
 
 # 3. Detect flags
@@ -202,12 +206,19 @@ ARGS_CLEAN=$(echo "$ARGUMENTS" | awk '{
 # --auto-decide-dominant remains accepted as an explicit opt-in (no-op when default is true)
 # for backward-compatible invocations and documentation clarity.
 BASE_MODE=false
+CHANGES_MODE=false
 AUTO_DECIDE_INITIAL=true
 for arg in $ARGUMENTS; do
   [ "$arg" = "--base" ] && BASE_MODE=true
+  [ "$arg" = "--changes" ] && CHANGES_MODE=true
   [ "$arg" = "--auto-decide-dominant" ] && AUTO_DECIDE_INITIAL=true
   [ "$arg" = "--no-auto-decide-dominant" ] && AUTO_DECIDE_INITIAL=false
 done
+
+# 3.5. USER_NOTE extraction (trailing free-text after doc-path token 1; positional, not a flag)
+# Blank token 1 (doc-path) and print the rest. Always run; empty when no trailing note.
+# Injected as {USER_NOTE} regardless of --changes: change focus when --changes, general review context otherwise.
+USER_NOTE=$(echo "$ARGS_CLEAN" | awk '{$1=""; sub(/^ +/,""); print}')
 
 # 4. REPO_NAME extraction (document stem → repo basename → cwd basename)
 REPO_NAME=$(echo "$ARGS_CLEAN" | awk '{print $1}' | xargs basename 2>/dev/null)
@@ -238,6 +249,8 @@ Document: $(echo "$ARGS_CLEAN" | awk '{print $1}')
 Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 AUTO_DECIDE_INITIAL: ${AUTO_DECIDE_INITIAL}
 BASE_MODE: ${BASE_MODE}
+CHANGES_MODE: ${CHANGES_MODE}
+USER_NOTE: ${USER_NOTE}
 -->
 EOF
 
@@ -350,7 +363,7 @@ Perform agent-based iterative review until severity saturation (§3.11). Each ro
 
 **Step 12** — `inner_round += 1`. Spawn a review agent.
 
-**Before spawning the review agent, Read `${CLAUDE_SKILL_DIR}/references/06-review-agent-prompt.md`** and substitute `{TEMP_DIR}` (= actual `INNER_TEMP_DIR`) and `{BASE_MODE_CONSTRAINT}` (the `--base` block when `BASE_MODE=true`, else empty) per the file's substitution contract, then prepend the path context block before calling `Agent()`.
+**Before spawning the review agent, Read `${CLAUDE_SKILL_DIR}/references/06-review-agent-prompt.md`** and substitute `{TEMP_DIR}` (= actual `INNER_TEMP_DIR`), `{USER_NOTE}` (the trailing note when non-empty, else empty), `{BASE_MODE_CONSTRAINT}` (the `--base` block when `BASE_MODE=true`, else empty), and `{CHANGES_MODE_CONSTRAINT}` (the `--changes` block when `CHANGES_MODE=true`, else empty) per the file's substitution contract, then prepend the path context block before calling `Agent()`.
 
 After the agent returns:
 
@@ -657,7 +670,23 @@ Verify consistency and completeness of the existing design content. Do NOT propo
 - DON'T propose: removing or reducing existing detailed design content.
 ```
 
-When `--base` is not present, remove the `{BASE_MODE_CONSTRAINT}` placeholder line from the agent prompt.
+When `--base` is not present, remove the `{BASE_MODE_CONSTRAINT}` placeholder line from the agent prompt. (LLM-equivalent to substituting a single empty line, as `06-review-agent-prompt.md`'s substitution contract phrases it; left unchanged as out of scope here.)
+
+### --changes
+
+Changes-consistency review mode. Orthogonal to `--base` and combinable with it (`--base --changes`): `--base` constrains the KIND of proposals allowed, `--changes` redirects the FOCUS/target of the review onto the modified material and its blast radius. When `$ARGUMENTS` contains `--changes`, substitute the following block for `{CHANGES_MODE_CONSTRAINT}` in the review agent prompt:
+
+```
+CHANGES MODE CONSTRAINT:
+This design document was already reviewed once; your job this round is to review the MODIFICATIONS made to it since then — for consistency with the rest of the document and for soundness in their own right. Actively judge what changed.
+- DO identify the changed material yourself: if a user-provided note appears above, treat it as the authoritative focus for what changed; otherwise infer the recently-modified or suspect sections from the document itself (newer or out-of-place phrasing, additions the surrounding sections have not caught up to, passages that now sit inconsistently against the rest).
+- DO verify ripple consistency: for each change, check that the rest of the document still agrees with it — data models, API contracts, sequence flows, requirement traces, and implementation order that reference or depend on the changed material must remain mutually consistent. Flag any section the change has left stale or contradictory.
+- DO re-question the changes themselves: do not assume a change is correct merely because it was made. Re-examine each change for soundness, completeness, and feasibility on its own terms, exactly as you would scrutinize a fresh design decision.
+- DON'T expend the round re-reviewing unchanged material the changes neither touch nor affect; concentrate effort on the changed material and its blast radius.
+- If a BASE MODE CONSTRAINT also appears above, it remains authoritative on the KIND of proposals you may emit: re-questioning a change must still respect it — surface inconsistencies, contradictions, and essential consistency supplements, but do NOT treat "re-questioning" as license to propose new task-level implementation detail or to remove/reduce existing detailed content. --base governs what kinds of findings are allowed; this block governs where you focus.
+```
+
+When `--changes` is not present, substitute the `{CHANGES_MODE_CONSTRAINT}` placeholder with a single empty line (per `06-review-agent-prompt.md`'s substitution contract). The reconcile bullet self-activates via its `"If a BASE MODE CONSTRAINT also appears above…"` wording, so no 4-way branch logic is needed — it is naturally inert when no BASE block precedes it.
 
 ### --auto-decide-dominant / --no-auto-decide-dominant
 

--- a/plugins/cc-cmds/skills/design-review/references/06-review-agent-prompt.md
+++ b/plugins/cc-cmds/skills/design-review/references/06-review-agent-prompt.md
@@ -1,6 +1,6 @@
 # Review Agent Prompt (§3.8)
 
-Agent prompt template for the inner-loop review agent. Consumed by Step 12 before spawning each fresh review agent. Before calling `Agent()`, substitute `{TEMP_DIR}` with the session's `INNER_TEMP_DIR` and `{BASE_MODE_CONSTRAINT}` either with the block from the `--base` Options section (when `BASE_MODE=true`) or with an empty line (when `BASE_MODE=false`).
+Agent prompt template for the inner-loop review agent. Consumed by Step 12 before spawning each fresh review agent. Before calling `Agent()`, substitute `{TEMP_DIR}` with the session's `INNER_TEMP_DIR`, `{USER_NOTE}` with the trailing user note (or an empty line when none), `{BASE_MODE_CONSTRAINT}` with the `--base` block (when `BASE_MODE=true`) or an empty line, and `{CHANGES_MODE_CONSTRAINT}` with the `--changes` block (when `CHANGES_MODE=true`) or an empty line — each substituted independently at a single level (see Substitution contract).
 
 ## Prompt body
 
@@ -25,7 +25,11 @@ Then read the design document and review it against ALL of the following criteri
 5. Missing items — Look for gaps: error handling not specified, edge cases not covered, security considerations absent, migration plans missing, rollback strategies undefined.
 6. Contextual review — Based on the specific domain and nature of this design, check for additional concerns that matter in this context but are not covered by the above categories.
 
+{USER_NOTE}
+
 {BASE_MODE_CONSTRAINT}
+
+{CHANGES_MODE_CONSTRAINT}
 
 IMPORTANT: Do NOT modify the design document directly. For every issue found, create a proposal in the following format:
 
@@ -72,8 +76,12 @@ Return a structured summary:
 
 ## Substitution contract
 
+Each placeholder is substituted **independently at a single level** — there are no nested tokens. Body placement order, top to bottom, is `{USER_NOTE}` → `{BASE_MODE_CONSTRAINT}` → `{CHANGES_MODE_CONSTRAINT}` (one readability blank line between each), so the CHANGES block's "if a user-provided note appears above" holds. This is the same single-placeholder operation as `--base`, repeated three times independently.
+
 - `{TEMP_DIR}`: replace with the absolute path of `INNER_TEMP_DIR` (computed at Step 7).
+- `{USER_NOTE}` (mode-independent, always evaluated): when `USER_NOTE` is empty, substitute a single empty line; when non-empty, substitute the single line `USER-PROVIDED NOTE (focus/context for this review): <USER_NOTE>`.
 - `{BASE_MODE_CONSTRAINT}`: when `BASE_MODE=true`, substitute the BASE MODE CONSTRAINT block from the `--base` Options section (SKILL.md); when `BASE_MODE=false`, substitute with a single empty line so the prompt structure remains stable.
+- `{CHANGES_MODE_CONSTRAINT}`: when `CHANGES_MODE=true`, substitute the CHANGES MODE CONSTRAINT block from the `--changes` Options section (SKILL.md) verbatim (static — it contains no nested token; the change focus is already carried by `{USER_NOTE}` above); when `CHANGES_MODE=false`, substitute with a single empty line.
 
 ## Path context prepend
 


### PR DESCRIPTION
## 개요

`design-review`·`design-review-lite`에 "이미 리뷰된 문서에 수정이 발생했을 때 그 수정 사항의 정합성을 검증"하는 사용 패턴을 옵션화한 `--changes` 플래그를 추가한다. 지금까지는 매번 `design-review <doc> 수정 사항 관련 정합성 검증`처럼 자연어 의도를 덧붙여 호출해야 했던 흐름을 재현 가능한 플래그로 만든다.

## 변경 내용

- **`--changes` 플래그** (양쪽 스킬): 리뷰 초점을 변경분 + 그 파급 반경으로 좁히는 리다이렉트. (a) 파급 정합성(각 변경이 데이터 모델·API 계약·시퀀스 흐름·요구사항 추적·구현 순서 등 문서 나머지와 여전히 일치하는지)과 (b) 변경 자체의 재질의(변경됐다는 이유로 옳다고 가정하지 않고 신규 설계 결정처럼 타당성·완결성·실현가능성 재검토) 두 갈래로 검증하도록 `CHANGES MODE CONSTRAINT` 블록을 리뷰 에이전트 프롬프트에 주입한다. git diff·스냅샷 없는 프롬프트 주입 방식으로, 에이전트가 능동적으로 무엇이 바뀌었는지 판단한다.
- **`--base`와 직교·조합 가능**(`--base --changes`): `--base`는 *허용되는 제안의 종류*를 제약하는 필터, `--changes`는 *리뷰의 초점/대상*을 바꾸는 리다이렉트. 조합 시 reconcile 불릿이 `"If a BASE MODE CONSTRAINT also appears above…"` 문장으로 자체 활성화되어 base의 제안-종류 제약을 준수하므로 4-way 분기 로직이 불필요하다.
- **사용자 참고 노트(범용 위치 인자)**: doc-path 뒤 trailing 자유텍스트를 `{USER_NOTE}` 블록으로 주입한다. `--changes` 유무와 무관하게 비어있지 않으면 항상 주입되며, `--changes` 시엔 "무엇이 바뀌었는지"의 권위 있는 변경 초점, 꺼져 있으면 일반 리뷰 참고/초점 컨텍스트로 전달된다.
- **단일-레벨 치환 계약**: `{USER_NOTE}`/`{BASE_MODE_CONSTRAINT}`/`{CHANGES_MODE_CONSTRAINT}` 세 플레이스홀더를 각각 독립적으로 단일 레벨 치환(중첩 토큰 없음 — 모델이 2차 해소를 잊어 리터럴 토큰을 누출하는 drift 실패 모드 차단). 배치 순서는 위에서부터 `{USER_NOTE}` → `{BASE_MODE_CONSTRAINT}` → `{CHANGES_MODE_CONSTRAINT}`로, CHANGES 블록의 "if a user-provided note appears above"가 성립하도록 노트가 위에 온다.
- **audit provenance**: `outer_log.md` 헤더에 `CHANGES_MODE`·`USER_NOTE`를 무조건 기록(`BASE_MODE`와 패리티).

## 영향 범위

신규 disposition 태그를 도입하지 않으므로 종료 수학(`COUNT_APPLIED`/`escalate_applied`/`inner_converged_cleanly()`)·Self-Triage·severity·auto-decide 펜스에 변경이 없다. auto-decide는 main-session 전용이고 리뷰 에이전트에 전파되지 않으므로 에이전트-프롬프트 주입인 `--changes`와 동일 레이어를 건드리지 않는다.

inferred 모드(자유텍스트 노트 없이 `--changes`만)의 변경 탐지는 diff·스냅샷 없이 문서만 보고 휴리스틱하게 재구성하므로 본질적으로 부분적이며, 이는 수용된 설계 트레이드오프다 — 완화책은 자유텍스트 설명을 넘겨 hard focus signal로 격상하는 것이다.

## 버전

`1.9.0` → `1.10.0` (feat = minor bump). `make check`(lint + README 재생성) 통과.

## 검증

- `make lint` 통과 — `## Control-Flow Invariants` 위치 + 옵션 frontmatter 스키마 검증.
- README가 `--changes` 행으로 재생성됨(두 스킬 usage/옵션 표).
- 4가지 조합(neither / `--base`만 / `--changes`만 / both) 프롬프트 형태 대조.