### PR TITLE
fix(askuserquestion): 빈-input 붕괴 완화 authoring 가이드 (v1.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2026-06-04
+
+`AskUserQuestion`(AUQ) 호출이 간헐적으로 일으키는 "Invalid tool parameters" 에러의 96%는 모델이 도구 호출을 확정해 놓고 중첩 인자를 emit할 때 통째로 비워버리는 *빈-input 붕괴*(`tool_input == {}`, `questions` 누락)다. 1,544개 세션 로그 조사로 이 실패 모드를 확인하고, 공유 construction spec(`_common/askuserquestion.md`)에 짧은 authoring 가이드를 추가해 완화한다. 모든 스킬이 "every AUQ call"에 이 spec을 적용하므로 신규 단락이 자연히 전파된다 (`/plugin update cc-cmds`로 자동 반영).
+
+당초 PreToolUse 훅으로 빈 호출을 검증 전에 가로채 교정하려 했으나, 라이브 테스트에서 AUQ 스키마 검증이 어떤 훅 디스패치보다 먼저 실행되어 스키마-거부 호출은 훅에 도달하지 못함이 확인되었다. 호출-시점 인터셉트가 구조적으로 불가능하므로 반응형 훅 레버를 폐기하고 prose 단일 레버로 출하한다.
+
+### Changed
+
+- **`_common/askuserquestion.md` authoring 가이드 추가**: (a) intro의 scope 문장을 "construction-validity only"에서 "constructing and reliably emitting valid calls"로 넓혀 생성 slip로 호출이 비워지는 것을 피하는 것까지 포함한다. (b) `Two Axes` 섹션 끝에 단락 하나를 fold-in해 — 결정에 필요한 것 이상으로 호출을 키우지 말 것(옵션 padding 금지, 턴 절약 목적의 독립 질문 묶음 금지)과, 같은 호출이 3회 이상 재emit에도 계속 붕괴하면 그 질문을 번호 매긴 평문으로 전환해 자유 응답을 받는 best-effort 폴백을 안내한다. 크기-붕괴 인과는 측정되지 않은 가설이라 hedge로 명시하고, 폴백은 강제 수단이 없는(non-deterministic) 지시임을 caveat로 남긴다. 새 동작을 강제하지 않는 prompt/wording 조정이라 patch bump.
+
 ## [1.10.0] - 2026-06-04
 
 `design-review`와 `design-review-lite`에 "이미 리뷰된 문서에 수정이 발생했을 때 그 수정 사항의 정합성을 검증"하는 사용 패턴을 옵션화한 `--changes` 플래그를 추가한다. 지금까지는 매번 `design-review <doc> 수정 사항 관련 정합성 검증`처럼 자연어 의도를 덧붙여 호출해야 했던 흐름을 재현 가능한 플래그로 만든다. `--changes`는 기존 `--base`와 구조적으로 완전히 동형인 **프롬프트 주입 플래그**다 — git diff·스냅샷 같은 기계적 변경 식별 메커니즘은 도입하지 않고, 플래그가 켜지면 리뷰 에이전트 프롬프트에 `CHANGES MODE CONSTRAINT` 블록을 주입해 에이전트가 능동적으로 무엇이 바뀌었는지 판단한다 (`/plugin update cc-cmds`로 자동 반영).

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.10.0",
+    "version": "1.10.1",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/_common/askuserquestion.md
+++ b/plugins/cc-cmds/skills/_common/askuserquestion.md
@@ -1,6 +1,6 @@
 # AskUserQuestion (Shared Construction Spec)
 
-Single source of truth for constructing **valid** `AskUserQuestion` (AUQ) calls across skills. Scope is **construction-validity only** — how to shape a call the validator accepts. *Whether* and *when* to ask (e.g. one-issue-per-call policy, no-question entry points) stays in each skill; do not infer ask/skip policy from this file.
+Single source of truth for constructing **valid** `AskUserQuestion` (AUQ) calls across skills. Scope is **constructing and reliably emitting valid calls** — how to shape a call the validator accepts. *Whether* and *when* to ask (e.g. one-issue-per-call policy, no-question entry points) stays in each skill; do not infer ask/skip policy from this file.
 
 ## Hard Schema Constraints
 
@@ -18,6 +18,8 @@ These are independent limits — do not conflate them:
 - **Axis B — options per question**: each question carries 2–4 options.
 
 A call with one question of three options is valid; so is four questions each with two options. "Too many choices" almost always means Axis B (>4 options on one question), not Axis A.
+
+**Keep calls lean, and fall back if they collapse.** Most AUQ rejections are _empty-input collapse_ — the call commits but emits no `questions` (`{}`), so the validator reports `questions` missing; re-emitting usually succeeds. As authoring hygiene, keep each call no larger than the decision needs: don't pad options to four, and don't batch independent questions into one call just to save a turn (≤4 genuinely interdependent is fine). A leaner argument is _plausibly_ less prone to the slip, though we don't have data that size causes it. On a collapse, re-emit the complete call. **Only if it still collapses after three or more re-emits** should you stop calling AskUserQuestion for that question and ask it as a numbered plain-text list for a free-text answer — nothing enforces this, but switching surfaces is the only way to break a repeat-collapse run.
 
 ## The Auto-Provided "Other"
 


### PR DESCRIPTION
## 배경

`AskUserQuestion`(AUQ) 호출이 간헐적으로 "Invalid tool parameters" 에러를 일으킨다. 1,544개 세션 로그를 조사한 결과 실패 110건 중 **106건(96%)이 빈-input 붕괴**였다 — 모델이 도구 호출을 확정해 놓고 중첩 인자(`questions[] × options[] × {label, description}`)를 emit할 때 통째로 비워버리는 확률적 생성 slip(`tool_input == {}`, `questions` 누락, 에러 `The required parameter 'questions' is missing`). 스키마 지식 결함이 아니라(재시도하면 정상 호출됨) 직전 construction spec이 다룬 4% 구성-오류와는 전혀 다른 실패 모드다.

## 왜 prose-only인가 (hook 접근 폐기)

당초 PreToolUse 훅으로 빈 호출을 스키마 검증 전에 가로채 deny+교정하려 했으나, 라이브 테스트로 전제가 **반증**되었다:

- PreToolUse 훅(hot-reload 정상 확인)이 스키마-거부 AUQ(`questions:[]`, nested-minItems 위반)에 **미발동**. valid AUQ·Bash에는 발동.
- → AUQ 스키마 검증이 어떤 훅 디스패치보다 **먼저** 실행되어, 스키마-거부 호출은 훅에 도달하지 못하고 `InputValidationError`가 곧장 tool_result로 모델에 되먹여진다.

호출-시점 인터셉트가 구조적으로 불가능하므로 반응형 훅 레버를 전면 폐기하고 prose 단일 레버로 출하한다.

## 변경 내용

`_common/askuserquestion.md` 문구 2건 (모든 스킬이 "every AUQ call"에 이 spec을 적용하므로 자연 전파):

- **intro scope broadening**: "construction-validity only" → "constructing and reliably emitting valid calls" (생성 slip로 비워지는 것 회피까지 포함)
- **`Two Axes` 섹션 fold-in 단락**: 결정에 필요한 것 이상으로 호출을 키우지 말 것(옵션 padding 금지, 턴 절약 목적의 독립 질문 묶음 금지)과, 같은 호출이 **3회 이상 재emit에도 계속 붕괴하면** 번호 매긴 평문으로 전환해 자유 응답을 받는 best-effort 폴백 안내. 크기-붕괴 인과는 측정되지 않은 가설이라 hedge로 명시, 폴백은 강제 수단 없음을 caveat로 명시.

새 enforced 동작 없는 prompt/wording 조정이라 **patch bump (1.10.0 → 1.10.1)**.

## 검증

- `make check` 통과 (lint-skill-auq-spec 포함 전체 lint + README stale 0)