### PR TITLE
feat(design-upgrade): 모델·역할 두 축 강화 분석으로 확장

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-06-04
+
+`/cc-cmds:design-upgrade`를 "모델 상향 단일 축" second-opinion에서 **모델·역할 두 축을 함께 추론하는 팀 구성 강화 분석**으로 확장한다. 기존 모델 승격(haiku/sonnet → opus)에 더해, 직전 `/design` 팀 구성에서 (a) 어떤 팀원도 소유하지 않은 누락 도메인을 메우는 신규 역할 추가, (b) 과부하된 광범위 역할 하나를 둘로 쪼개는 분할을 함께 짚어준다. 이름·zero-arg·`disable-model-invocation: true`·"직전 제안이 컨텍스트에 있어야 동작"하는 성격은 모두 보존하며, "강화가 유의미할 때만 제안, 그 외엔 유지 사유"라는 절제 원칙을 역할 축까지 대칭 확장한다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Changed
+
+- **`design-upgrade` 두 축 확장**: SKILL.md 본문을 영문 프로즈·영문 헤딩(`Scope`/`Evaluation criteria`/`Output format`/`Cross-axis synthesis`/`Precondition`/`Fallback`)으로 재작성하고 frontmatter `description`·`when_to_use`·`notes`를 두 축 분석에 맞게 재프레이밍한다(사용자 대면 한국어 어휘 `현재 모델 → 권장 모델`·`변경 사유`/`유지 사유`·`기대 효과`·`역할 변경 불필요`·필드 라벨 `역할`/`탐색 범위`/`모델`은 유지). 모든 권장은 명시적 OPERATION 태그(`UPGRADE`/`ADD`/`SPLIT-REPLACE`)를 달아 `/design` Step 2 재제안 입력으로 모호함 없이 해석되게 한다 — `UPGRADE`는 기존 로스터 역할명을 lookup key(공백 제거 후 정확 일치, 흔들림은 malformed→재확인)로 쓰고 미변경 `탐색 범위`는 생략, `ADD`는 기존 로스터와 충돌하지 않는 신규 역할 1건, `SPLIT-REPLACE`는 부모→자식 둘 + `PARTITION` 무손실·무중복 계약. 기존 역할당 OPERATION 최대 1개 불변식과, 두 축이 같은 약점을 겨냥하면 더 강한 한쪽만 택하는 교차축 통합 추론을 포함한다.
+- **역할 갭 탐지 + HARD LIMIT**: 4단계 coverage diff(도메인 열거 → 커버리지 맵 → 미커버 플래그 → 절제 게이트)를 **단일 패스**로 수행하며 iterate-until 루프·종료 계약이 없어 invariants lint exemption을 유지한다. 경량 재탐색은 read-only(팀·쓰기·test/build·MCP 금지)로 제안/인터뷰가 언급한 surface와 인접 sibling에 한정하고, ≤12 read-only 연산·단일 grep >50 hit는 ADD엔 inconclusive(SPLIT 후보의 과부하 입력으로는 유효)·확증 전용(fishing 금지)의 HARD LIMIT를 둔다. 절제 게이트·분할 게이트는 각각 ALL 충족 조건으로 "변경 없음"을 기본값으로 bias한다.
+- **precondition 부재 시 3-path fallback 인코딩**: (1) 세션 로스터 붙여넣기 → 완전한 두 축 분석, (2) 저장된 설계 문서에서 역산 → 모델 배정 부재로 역할 축만 가능한 degraded 모드(교차축 화해를 N/A 처리), (3) 둘 다 없으면 한국어 안내 emit 후 종료(자동 `/design` 체이닝 안 함). 현재 커맨드가 이미 즉흥 제시하던 emergent 동작을 SKILL에 인코딩한다.
+- **design-lite 충돌 가드 + 단방향 sync-note**: `design-lite` 구성(고정 2×sonnet, opus 제외)으로 보이면 두 강화 축이 lite 계약과 충돌하므로 caveat 후 명시 확인에만 진행하며, `design-lite/SKILL.md`의 상호 참조 문구도 두 축 반영으로 갱신해 양방향 정합을 맞춘다. OPERATION 라벨·모델 별칭의 source-of-truth가 `design/SKILL.md` Step 2 필드 세트임을 명시하는 단방향 sync-note를 `design-upgrade`에만 추가한다(`design/SKILL.md` 미접촉).
+
+### Why
+
+확장의 핵심은 "이름·호출 방식·second-opinion 성격은 그대로 두고 분석 축만 하나 더 얹는다"이다. 역할 축을 강화 방향(추가·분할)으로만 한정하고 제거·병합·모델 하향을 범위 밖으로 둔 것은 `upgrade` 의미를 깨지 않기 위함이며, 절제 게이트를 통과 못 하면 "변경 불필요"가 정상 출력이 되도록 한 것은 기존 모델 축의 유지 사유 대칭을 그대로 잇기 위함이다. OPERATION 태그는 재제안 루프(분석을 컨텍스트에 되먹여 다시 팀 구성)의 입력을 기계적으로 재구성 가능하게 만드는 계약이지 자동 ingestion 경로가 아니다 — 적용은 사람/다음 turn 모델이 수행한다.
+
 ## [1.10.1] - 2026-06-04
 
 `AskUserQuestion`(AUQ) 호출이 간헐적으로 일으키는 "Invalid tool parameters" 에러의 96%는 모델이 도구 호출을 확정해 놓고 중첩 인자를 emit할 때 통째로 비워버리는 *빈-input 붕괴*(`tool_input == {}`, `questions` 누락)다. 1,544개 세션 로그 조사로 이 실패 모드를 확인하고, 공유 construction spec(`_common/askuserquestion.md`)에 짧은 authoring 가이드를 추가해 완화한다. 모든 스킬이 "every AUQ call"에 이 spec을 적용하므로 신규 단락이 자연히 전파된다 (`/plugin update cc-cmds`로 자동 반영).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Engineering workflow commands for Claude Code.
 | `/cc-cmds:design-review` | 설계 문서 최종 리뷰 | 작성된 설계 문서를 다중 반복 에이전트 리뷰(외부/내부 사이클)로 최종 검증·수렴시키고자 할 때 |
 | `/cc-cmds:design-review-lite` | 설계 문서 경량 사이클 리뷰 | 설계 문서를 간결한 반복 사이클로 빠르게 검증하고 싶을 때 (미묘한 termination invariant·동시성 검출률 약화 가능) |
 | `/cc-cmds:design-system` | Claude Design (claude.ai/design) DS 생성 프롬프트 emit + DS 번들 ingest로 docs/design-system/ 워크스페이스 구축 (2-phase) | FE 파이프라인 시작 전 프로젝트 전역 design system을 claude.ai/design으로 생성·도입할 때 (1회성 또는 재ingest) |
-| `/cc-cmds:design-upgrade` | 팀원 모델 업그레이드 분석 | design 스킬의 팀 구성 제안에서 haiku/sonnet으로 배정된 팀원 중 opus로 승격이 유의미한 역할이 있는지 검토할 때 |
+| `/cc-cmds:design-upgrade` | 팀 구성 강화 분석 (모델·역할 축) | 직전 `/design` 팀 구성 제안에서 opus 승격이 유의미한 역할이 있는지, 또는 누락 도메인을 메울 신규 역할·과부하 역할 분할이 필요한지 second-opinion으로 검토할 때 |
 | `/cc-cmds:implement` | 설계 문서 기반 구현 | 사용자가 작성된 설계 문서를 바탕으로 단계적 계획을 세우고 실제 구현을 수행하기를 원할 때 |
 | `/cc-cmds:review` | 에이전트 팀을 활용한 다관점 코드 리뷰 | 사용자가 PR/로컬 diff/파일 경로에 대한 다관점 코드 리뷰(보안/성능/품질 등)를 요청할 때 |
 | `/cc-cmds:review-lite` | 2인 팀을 활용한 경량 코드 리뷰 | 빠른 코드 리뷰가 목적이고 다관점 심층 분석이 불필요할 때 (큰 PR coverage gap, 미묘한 race condition·authn bypass 검출률 약화 가능) |
@@ -228,7 +228,7 @@ npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-gu
 
 **Usage**: `/cc-cmds:design-upgrade`
 
-_이 커맨드는 별도 인자를 받지 않으며, 직전 `/design` 팀 제안이 현재 대화 컨텍스트에 있어야 동작한다. 독립 실행 시 결과가 불정확할 수 있다._
+_이 커맨드는 별도 인자를 받지 않으며, 직전 `/design` 팀 구성 제안이 현재 대화 컨텍스트에 있어야 동작한다. 모델 승격과 역할 추가·분할은 강화가 유의미할 때만 제안하며, 그 외에는 유지 사유를 제시한다. 독립 실행 시 결과가 불정확할 수 있다._
 
 ### /cc-cmds:implement
 

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.10.1",
+    "version": "1.11.0",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/design-lite/SKILL.md
+++ b/plugins/cc-cmds/skills/design-lite/SKILL.md
@@ -76,7 +76,7 @@ This skill is the lightweight sibling of `design`. It trades depth for predictab
 
 - NO code modifications. Design discussion only.
 - Inter-agent communication must be in English.
-- **Sonnet pin**: every teammate uses model `"sonnet"`. Haiku is forbidden; opus upgrade is out of scope (use `/cc-cmds:design-upgrade` against a base `/cc-cmds:design` run instead).
+- **Sonnet pin**: every teammate uses model `"sonnet"`. Haiku is forbidden; both of `/cc-cmds:design-upgrade`'s reinforcement axes are out of scope here — opus upgrade violates the sonnet pin, and role add/split mutates the fixed 2-member roster (run `/cc-cmds:design-upgrade` against a base `/cc-cmds:design` run instead).
 - **No Sequential Thinking MCP, no Claude Context MCP**: lite contract — predictable token cost.
 - **Agent Team required**: TeamCreate + SendMessage only. Do NOT substitute with isolated Agent sub-agents.
 - **Deferred tool loading**: Before using AskUserQuestion, TeamCreate, SendMessage, or TeamDelete, you MUST first load them via ToolSearch. Run `ToolSearch` with query "select:AskUserQuestion", "select:TeamCreate", "select:SendMessage", and "select:TeamDelete" to load each tool. AskUserQuestion MUST be loaded before Step 1 (user interview). Before calling AskUserQuestion, Read `${CLAUDE_SKILL_DIR}/../_common/askuserquestion.md` and apply its hard constraints to every AskUserQuestion call in this skill.

--- a/plugins/cc-cmds/skills/design-upgrade/SKILL.md
+++ b/plugins/cc-cmds/skills/design-upgrade/SKILL.md
@@ -1,23 +1,107 @@
 ---
 name: design-upgrade
-description: 팀원 모델 업그레이드 분석
-when_to_use: design 스킬의 팀 구성 제안에서 haiku/sonnet으로 배정된 팀원 중 opus로 승격이 유의미한 역할이 있는지 검토할 때
+description: 팀 구성 강화 분석 (모델·역할 축)
+when_to_use: 직전 `/design` 팀 구성 제안에서 opus 승격이 유의미한 역할이 있는지, 또는 누락 도메인을 메울 신규 역할·과부하 역할 분할이 필요한지 second-opinion으로 검토할 때
 disable-model-invocation: true
 usage: "/cc-cmds:design-upgrade"
 options: []
 notes: |
-    이 커맨드는 별도 인자를 받지 않으며, 직전 `/design` 팀 제안이 현재 대화 컨텍스트에 있어야 동작한다. 독립 실행 시 결과가 불정확할 수 있다.
+    이 커맨드는 별도 인자를 받지 않으며, 직전 `/design` 팀 구성 제안이 현재 대화 컨텍스트에 있어야 동작한다. 모델 승격과 역할 추가·분할은 강화가 유의미할 때만 제안하며, 그 외에는 유지 사유를 제시한다. 독립 실행 시 결과가 불정확할 수 있다.
 ---
 
-haiku, sonnet으로 제안된 팀원 중 opus로 변경하면 이점이 있는 팀원이 있는지 분석해줘.
+Analyze the team composition proposed in the preceding `/design` Step 2 output and produce a second opinion along **two axes** — model and role — recommending only *reinforcing* changes. Restraint is the default: `역할 변경 불필요` / `모델 변경 불필요` (no change needed) is a valid and expected outcome on either axis.
 
-## 판단 기준
+## Scope
 
-복잡한 추론, 크로스 도메인 분석, 깊은 코드 분석 등 opus의 강점이 유의미한 차이를 만들 수 있는 역할을 중심으로 판단하되, 해당 설계의 특성에 따라 다른 관점도 고려할 것.
+Two analysis axes, reinforcement-direction only:
 
-## 출력 형식
+- **Model axis** (existing behavior): among teammates assigned `haiku`/`sonnet`, identify those where opus's strengths — complex reasoning, cross-domain analysis, deep code analysis — would make a meaningful difference, and propose promotion to opus.
+- **Role axis** (new): (a) **ADD** a new role for an in-design-scope domain that no current teammate owns, or (b) **SPLIT-REPLACE** one overloaded broad role into two.
 
-팀원별로 다음을 제시:
-- 현재 모델 → 권장 모델
-- 변경 사유 (또는 유지 사유)
+**Out of scope — never propose**: role removal, role merge, model downgrade.
+
+**Restraint principle (most important)**: just as model promotion is proposed only when it makes a meaningful difference, role ADD/SPLIT is proposed only when needed — not always. "변경 불필요" is the default and a normal output on both axes; mirror the existing retain-rationale symmetry onto the role axis.
+
+## Evaluation criteria
+
+### Role-gap detection (single pass)
+
+Four-step coverage diff: enumerate domains → build a coverage map → flag uncovered domains → apply the restraint gate (most candidates drop here). This is a **single pass** — no iterate-until loop and no termination contract.
+
+Lightweight re-exploration (read-only; no team, no writes, no test/build, no MCP): grep/ls limited to surfaces the proposal/interview already named and their adjacent sibling directories, plus single-file Read ≤200 lines.
+
+**HARD LIMIT**:
+
+1. ≤12 total read-only operations/calls; on exhaustion, stop (uncharacterized domains default to no change).
+2. A single grep with >50 hits is inconclusive for ADD — treat it as an already-central domain, not gap evidence (bias to no change). This bias applies **only to new-domain discovery (ADD)**; the same large hit can serve as overload input for a SPLIT candidate under the split gate, so do NOT silence SPLIT reasoning at the grep step.
+3. make/test/build, team spawn, MCP, and writes are fully prohibited.
+4. Re-exploration is confirmatory — confirm only gaps the interview/task already implied; do not fish for new out-of-scope domains. Inconclusive → bias to "no change".
+
+### Restraint gate (new role — ALL required)
+
+1. A specific uncovered domain that no role owns (cite path / requirement).
+2. ≥1 consequential, non-mechanical design decision living in that domain.
+3. Distinct expertise an existing role would not naturally produce within its scope.
+
+If any fails → no new role. Expanding an existing role's scope (absorption) is out of scope, so a confirmed gap is handled as a **new role**, not a scope edit.
+
+### Split gate (ALL required)
+
+1. The scope spans two separable domain clusters, each with independent decisions (aligned with the 1→2 partition contract below — if 3+ distinct domains, split only the single strongest cleavage this round and defer the residual overload to the next re-proposal round).
+2. Depth contention — one teammate would starve one side.
+3. Clean cleavage — no shared core forcing constant cross-talk.
+4. Cross-axis reconciliation — explicitly compare SPLIT (two sonnets, parallel focus, +coordination cost, +1 headcount) vs UPGRADE (one opus spanning both, single synthesis preserved), then pick one.
+
+## Output format
+
+Every recommendation carries an explicit OPERATION tag so the user or the next-turn model can re-feed it into `/design` Step 2 re-proposal without ambiguity (there is no ingestion path that auto-applies these tags). Field labels are Korean — `역할` / `탐색 범위` / `모델` — conceptually aligned with Step 2's English-prose fields (role / exploration scope / model); only the model-value aliases `"opus"` / `"sonnet"` / `"haiku"` are tokens shared verbatim across both sides.
+
+### `UPGRADE` (existing teammate, model axis)
+
+- `역할` — must match an existing roster role name (lookup key). Comparison is exact string match after trimming leading/trailing whitespace; any other drift (case, parenthetical-note differences, etc.) is malformed → re-confirm with the user. Never silently create a new entry.
+- `현재 모델 → 권장 모델`
+- 변경 사유
 - 기대 효과
+
+Omit `탐색 범위` — only the model cell changes, so restating the unchanged scope is noise and a stale-copy risk.
+
+### `ADD` (new role)
+
+- Full `역할 / 탐색 범위 / 모델` for one item
+- 근거 (the uncovered domain)
+- 기대 효과
+
+The new `역할` name must not collide with any existing roster role name — a collision means this is a scope-expansion attempt on an existing role, which is out of scope (fails the restraint gate). Symmetric with UPGRADE's lookup-key integrity.
+
+### `SPLIT-REPLACE` (overloaded parent role → two children, parent removed)
+
+- Each of the two children: `역할 / 탐색 범위 / 모델`
+- `PARTITION: childA.탐색 범위 ⊎ childB.탐색 범위 = parent.탐색 범위 (no overlap, no loss)`
+- 근거 (overload evidence)
+- 기대 효과
+
+A SPLIT-REPLACE making the parent role name disappear is NOT the forbidden "removal" — it is a reinforcing 1→2 split. Tag it `SPLIT-REPLACE`, not `REMOVE`, so the re-proposal does not misread it as a downgrade.
+
+### Invariant — at most one OPERATION per existing role
+
+A single parent role must not carry both `UPGRADE` and `SPLIT-REPLACE`. If both seem valid, pick the stronger one and state the tradeoff. `ADD` does not touch existing roles, so it combines freely.
+
+## Cross-axis synthesis
+
+Weigh both axes together. When the same weakness is targeted by both a model promotion and a role change, choose only the stronger side and state the tradeoff explicitly (e.g., "promote teammate X to opus" vs "add a new opus role dedicated to domain Y").
+
+## Precondition
+
+This skill requires the preceding `/design` Step 2 team composition to be in context. It is a `disable-model-invocation: true` second-opinion skill and does NOT auto-chain `/design`.
+
+**design-lite conflict guard**: if the in-context proposal looks like a `/design-lite` composition (fixed 2×sonnet, opus excluded), both reinforcement axes conflict with the lite contract — UPGRADE→opus violates the sonnet pin, and ADD/SPLIT mutate the fixed roster. Emit the caveat and proceed only on explicit user confirmation. (Consistent with the cross-reference in `design-lite/SKILL.md`.)
+
+**Schema-drift sync note**: the source of truth is `design/SKILL.md` Step 2's team-composition field set (role / exploration scope / model, plus the model-alias set — English prose). If Step 2 changes that field set, manually sync this skill's OPERATION Korean labels and model aliases (the Korean labels are this skill's emit surface, conceptually corresponding to Step 2's English fields). Do NOT touch `design/SKILL.md`. The residual risk of a missed sync is accepted without a lint.
+
+## Fallback
+
+When the precondition is not met, follow a 3-path fallback:
+
+- **Path 1 — session roster paste**: the user pastes the Step 2 composition → full two-axis analysis.
+- **Path 2 — reverse-engineer from a saved design doc (degraded — role axis only)**: `docs/<slug>.md` captures architecture/scope but does NOT save the Step 2 roster (Step 4 saves only architecture / decisions / issues / order). Role-gap detection is possible from the doc's scope, but the model axis is not (no current model assignments). State this limitation when taking this path. Because the model axis is impossible at the source, the split gate's cross-axis reconciliation and the Cross-axis synthesis treat the UPGRADE comparison term as N/A and proceed on the role axis alone (skip the SPLIT-vs-UPGRADE tradeoff weighing). Also, since no interview is in session, the lightweight re-exploration anchor is the saved doc's architecture/scope narrative instead of the interview — limit to surfaces the doc cites/names and their adjacent siblings under the same HARD LIMIT.
+- **Path 3 — start a new `/design`**: when neither is available, two-axis analysis is impossible — emit a Korean notice (e.g., *"분석할 팀 구성이 없습니다. 먼저 `/cc-cmds:design`을 실행해 팀 구성을 받은 뒤 다시 호출하세요."*) and stop.


### PR DESCRIPTION
## 개요

`/cc-cmds:design-upgrade`를 "모델 상향 단일 축" second-opinion에서 **모델·역할 두 축을 함께 추론하는 팀 구성 강화 분석**으로 확장한다. 이름·zero-arg·`disable-model-invocation: true`·"직전 `/design` 제안이 컨텍스트에 있어야 동작"하는 성격은 모두 보존하며, 분석 축만 하나 더 얹는다.

## 주요 변경

- **역할 축 신규**: 직전 `/design` 팀 구성에서 (a) 어떤 팀원도 소유하지 않은 누락 도메인을 메우는 신규 역할 추가(ADD), (b) 과부하된 광범위 역할 하나를 둘로 쪼개는 분할(SPLIT-REPLACE)을 모델 승격과 함께 추론한다. 제거·병합·모델 하향은 범위 밖.
- **절제 원칙 대칭 확장**: "강화가 유의미할 때만 제안, 그 외엔 유지 사유"를 역할 축까지 확장. "변경 불필요"가 기본값이자 정상 출력.
- **OPERATION 태그 출력 계약**: 모든 권장에 `UPGRADE`/`ADD`/`SPLIT-REPLACE` 태그를 달아 `/design` Step 2 재제안 입력으로 모호함 없이 해석되게 한다. UPGRADE는 기존 로스터 역할명 lookup-key 무결성(공백 제거 후 정확 일치, 흔들림은 재확인), SPLIT-REPLACE는 `PARTITION` 무손실·무중복 계약, 역할당 OPERATION 최대 1개 불변식 포함.
- **역할 갭 탐지 + HARD LIMIT**: 4단계 coverage diff를 read-only 단일 패스(≤12 연산, grep>50 hit는 ADD엔 inconclusive)로 한정. 절제 게이트·분할 게이트로 과잉 제안 차단.
- **3-path fallback**: precondition 부재 시 (1) 세션 로스터 붙여넣기, (2) 저장 설계 문서 역산(모델 배정 부재로 역할 축만 가능한 degraded 모드), (3) 안내 후 종료.
- **design-lite 정합**: Sonnet pin 문구를 두 강화 축이 lite 계약과 충돌함을 반영하도록 갱신(양방향 상호 참조 정합).
- **본문 영문화**: SKILL.md 본문·헤딩을 영문 prose로 재작성(사용자 대면 한국어 어휘 유지). source-of-truth sync-note 추가.

## 버전

`1.10.1 → 1.11.0` (minor). CHANGELOG `[1.11.0]` 추가.