### PR TITLE
feat(review): 발견 항목에 붙여넣기용 코멘트 기본 산출

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-06-04
+
+`/cc-cmds:review` 리포트가 각 발견 항목 아래에 **GitHub에 그대로 붙여넣을 수 있는 정중체 코멘트를 기본 산출**하도록 확장한다. 지금까지는 발견 항목을 단정체 분석(근거/제안)으로만 기술해, 사용자가 PR에 코멘트를 달려면 매번 손으로 정중체로 옮겨 적어야 했다. 이제 P0~P2 항목은 분석 바로 아래에 `💬 붙여넣기용 코멘트` 블록쿼트를, P3 항목은 항목 한 줄 자체를 정중체·자기완결로 작성해 복사-붙여넣기만으로 인라인 코멘트를 게시할 수 있다. 코멘트는 Step 5에서 리드가 단독 작성하며(리뷰어 산출 포맷·컨텍스트 패키지는 무변경), 적용 범위는 `review` 한정(`review-lite` 제외) (`/plugin update cc-cmds`로 자동 반영).
+
+### Added
+
+- **붙여넣기용 코멘트 기본 출력** (`review` Step 5): P0~P2 발견 항목마다 분석(근거/💡 수정 제안) 아래에 `💬 붙여넣기용 코멘트` 블록쿼트를 둔다. 라벨은 블록쿼트 밖 평문, 블록쿼트(`>`)에는 붙여넣을 본문(`> **P{N}: 재진술.**` + `> **[근거]**` + `> **[제안]**`)만 담아 사용자가 블록쿼트만 복사하면 메타 라벨 오염 없이 그대로 게시할 수 있다. 제목은 산문만, 이슈 위치(`파일:라인`)는 `[근거]` 첫 언급에 두어 인라인·일반 PR 코멘트 양쪽에서 자기완결이다. 심각도별로 P0/P1은 근거·제안 필수, P2는 근거 필수에 `[제안]`은 분석에 `💡 수정 제안`이 있을 때만(분석에 없는 제안을 코멘트가 창작하지 않도록 게이팅), P3는 블록쿼트 없이 항목 한 줄이 곧 코멘트(줄 끝 `— 리뷰어명` attribution은 복사 시 제외)다. 기존 PR 코멘트를 확인만 하는 항목(`📎 관련 PR 코멘트` 보유)은 중복 코멘트 대신 한 줄 평문 노트만 두며, 블록쿼트 부재가 "새로 게시할 코멘트 없음" 신호가 된다. 비-PR 모드(로컬 diff/파일 경로)에서도 코멘트는 그대로 생성되어 PR 개설·커밋 메시지·이슈 등 어디든 이식 가능하다.
+
+### Changed
+
+- **`review` 리포트 템플릿·Step 5 갱신**: `references/02-review-report-template.md`에 신규 "Paste-Ready Comment Blockquote" 섹션(골격·톤 이중성·심각도 표·dedup 예외)을 추가하고, Document Structure 코드블록의 P0/P1/P2 항목에 `💬 붙여넣기용 코멘트` 앵커, P3 예시를 정중체·자기완결로, 개요 `발견 요약` 아래에 코멘트 관례 설명 1줄을 고정한다. `SKILL.md` Step 5에는 코멘트 생성·톤 이중성(분석=단정체/코멘트=정중체)·dedup 예외·P3 한 줄 정중체 규칙 문단과 신규 섹션을 지목하는 템플릿 Read 라인을 추가한다. `references/03-non-pr-mode.md`에는 비-PR 모드의 이식형 코멘트 생성을 1줄 명시한다. 리뷰어 컨텍스트 패키지(`01-reviewer-context-package.md`)는 lead-only 작성 결정에 따라 무변경이다.
+
 ## [1.11.0] - 2026-06-04
 
 `/cc-cmds:design-upgrade`를 "모델 상향 단일 축" second-opinion에서 **모델·역할 두 축을 함께 추론하는 팀 구성 강화 분석**으로 확장한다. 기존 모델 승격(haiku/sonnet → opus)에 더해, 직전 `/design` 팀 구성에서 (a) 어떤 팀원도 소유하지 않은 누락 도메인을 메우는 신규 역할 추가, (b) 과부하된 광범위 역할 하나를 둘로 쪼개는 분할을 함께 짚어준다. 이름·zero-arg·`disable-model-invocation: true`·"직전 제안이 컨텍스트에 있어야 동작"하는 성격은 모두 보존하며, "강화가 유의미할 때만 제안, 그 외엔 유지 사유"라는 절제 원칙을 역할 축까지 대칭 확장한다 (`/plugin update cc-cmds`로 자동 반영).

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.11.0",
+    "version": "1.12.0",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/review/SKILL.md
+++ b/plugins/cc-cmds/skills/review/SKILL.md
@@ -292,9 +292,18 @@ Branch on user response:
 
 ### Step 5: Result Synthesis & Documentation (Korean)
 
-**Before synthesizing review results, Read `${CLAUDE_SKILL_DIR}/references/02-review-report-template.md`** for the severity system (P0~P3), merge rules, document structure template, and file naming/version conventions.
+**Before synthesizing review results, Read `${CLAUDE_SKILL_DIR}/references/02-review-report-template.md`** for the severity system (P0~P3), merge rules, document structure template, file naming/version conventions, and paste-ready comment generation (its "Paste-Ready Comment Blockquote" section).
 
 The lead synthesizes all review results into a Korean document under `docs/reviews/` following the template.
+
+#### Paste-ready comments (lead-authored)
+
+Below each P0~P2 finding's analysis (근거 / 💡 수정 제안), the lead writes a self-contained, paste-ready GitHub comment as a `💬 붙여넣기용 코멘트` blockquote, following the "Paste-Ready Comment Blockquote" section of `02-review-report-template.md`. The label sits outside the blockquote; the blockquote holds only the comment body so the user can copy it straight into a GitHub inline comment.
+
+- **Tone duality**: the analysis body is assertive (단정체); the comment is polite (정중체) — facts as `~됩니다 / ~입니다` (no hedging on a confirmed bug), requests as `~하시면 될 것 같습니다 / ~해주시면 좋겠습니다` (`~해야 합니다` only for P0 merge-block intent; never `~하세요`). The comment reads standalone, with no "위 분석 참조" cross-reference.
+- **P3 = the item line is the comment**: write each P3 line itself in polite, self-contained form from the start (no separate blockquote / `[근거]` / `[제안]`); the trailing `— {리뷰어명}` attribution is excluded when copied.
+- **dedup exception**: when a finding only confirms an existing PR comment (carries `📎 관련 PR 코멘트`), do NOT add a paste-ready blockquote — leave a single plain-text note (`이미 PR 코멘트 #N에서 제기된 사항입니다 …`) instead. The absence of a blockquote signals "nothing new to post".
+- **Non-PR mode**: comments are still generated (they are portable to a future PR, commit message, or issue); the dedup exception does not apply since there are no existing PR comments.
 
 ---
 

--- a/plugins/cc-cmds/skills/review/references/02-review-report-template.md
+++ b/plugins/cc-cmds/skills/review/references/02-review-report-template.md
@@ -52,6 +52,56 @@ When multiple reviewers raise issues at the same location:
 
 "Non-obvious" criteria: 3+ equally valid approaches exist, fix impacts other modules, or domain knowledge is required.
 
+## Paste-Ready Comment Blockquote
+
+Each P0~P2 finding carries a self-contained, paste-ready GitHub comment directly below its analysis (근거 / 💡 수정 제안). The lead authors these during Step 5 synthesis — reviewers (Step 4) never pre-write them, since P-levels are only fixed after the internal 5-level → 4-level mapping. The user copies the blockquote and pastes it straight into a GitHub inline comment with no rewriting.
+
+**Skeleton** (list sub-bullet, 4-space indent; the label is plain text *outside* the blockquote, and the blockquote `>` holds *only the comment body*):
+
+```
+    💬 **붙여넣기용 코멘트**
+
+    > **P{N}: [자기완결적 한 문장 재진술, 마침표로 끝].**
+    >
+    > **[근거]**
+    > [정중체 근거 — 이슈 위치를 첫 언급에서 `파일:라인`으로 명시]
+    >
+    > **[제안]**
+    > [💡 수정 제안을 정중체로 재진술]
+```
+
+- **Label outside the blockquote**: the `💬 붙여넣기용 코멘트` label is a plain paragraph; the blockquote carries only the comment body. Copying just the blockquote pastes cleanly with no meta-label contamination (works for both raw-markdown copy and rendered-selection copy).
+- **Title = prose only** (no `파일:라인`); **location (`파일:라인`) goes in the first mention inside `[근거]`** → self-contained for both inline comments (line implicit) and general PR comments (path needed).
+- **Container = blockquote** (never a code fence — monospace rendering would destroy bold / inline-code formatting).
+- **Standalone reading**: the comment must read on its own, with no cross-reference such as "위 분석 참조".
+
+### Tone duality (분석 = 단정체 / 코멘트 = 정중체)
+
+The analysis body states facts assertively; the paste-ready comment is polite. Do not hedge a confirmed bug in the comment.
+
+- **Fact statements**: `~됩니다 / ~있습니다 / ~없습니다 / ~입니다` (no hedging — never `~인 것 같습니다` / `~일 수도 있습니다` for a confirmed bug).
+- **Requests / suggestions**: `~하시면 될 것 같습니다 / ~해주시면 좋겠습니다 / ~좋을 듯합니다` (`~해야 합니다` only when the P0 intent is to block merge; never `~하세요` / `~해라`).
+
+### Severity rules
+
+| Severity | Paste-ready comment | `[근거]` | `[제안]` |
+|----------|---------------------|---------|---------|
+| P0 | Blockquote | Required | Required |
+| P1 | Blockquote | Required | Required |
+| P2 | Blockquote | Required | Only when the analysis carries a `💡 수정 제안` |
+| P3 | Item line *is* the comment (no blockquote) | — | — |
+
+- P2 `[제안]` is gated on the presence of `💡 수정 제안` in the analysis (itself "non-obvious only" per Fix Suggestion Inclusion Rules) → the comment never invents a suggestion the analysis lacks.
+- **P3**: write the single item line itself in polite, self-contained form from the start (no separate blockquote / `[근거]` / `[제안]`). When copying a P3 line, **exclude the trailing `— {리뷰어명}` attribution** (it stays in the document for tracking but is not part of the comment). For P0~P2 the attribution lives on the header line outside the blockquote, so it is already excluded.
+
+### confirms-existing exception (dedup)
+
+When a finding only **confirms an existing PR comment** (it carries `📎 관련 PR 코멘트`), do NOT produce a duplicate paste-ready comment. Instead place a single plain-text note below the analysis — no blockquote, no `💬` label:
+
+> 이미 PR 코멘트 #N에서 제기된 사항입니다 — 해당 스레드에 동의하시거나 resolve 처리해주시면 될 것 같습니다.
+
+(If the thread reference is a URL, substitute `이미 [이 PR 코멘트](URL)에서 제기된 사항입니다`.) The absence of a blockquote on a confirms-existing finding is the signal for "nothing new to post" (P3 excepted — a P3 line is itself the comment). In the rare case a P3 line is itself confirms-existing, the dedup rule wins: do not post that line as a comment, leave only the confirms-existing plain note.
+
 ## Document Structure
 
 ```markdown
@@ -71,6 +121,8 @@ When multiple reviewers raise issues at the same location:
     - ...
 - **발견 요약**: 🔴 P0 N건 | 🟠 P1 N건 | 🟡 P2 N건 | 🟢 P3 N건
 
+각 P0·P1·P2 항목은 분석(근거/제안) 아래에 `💬 붙여넣기용 코멘트` 블록을 두어 GitHub 인라인 코멘트로 그대로 복사할 수 있게 했다(톤: 분석은 단정, 코멘트는 정중). P3는 항목 한 줄이 곧 코멘트다.
+
 ---
 
 ## 핵심 요약
@@ -87,6 +139,8 @@ Mention CI failure items if applicable.]
     - 💡 수정 제안: [specific fix direction or example code]
     - 📎 관련 PR 코멘트: [@author의 기존 코멘트 참조] (if applicable)
 
+    💬 붙여넣기용 코멘트 ← "Paste-Ready Comment Blockquote" 섹션 참조 (📎로 confirms-existing이면 블록쿼트 대신 평문 노트)
+
 ## 🟠 P1 (머지 전 수정 권장)
 
 - **[category]** `파일:라인` 이슈 설명 — 리뷰어
@@ -94,16 +148,20 @@ Mention CI failure items if applicable.]
     - 💡 수정 제안: [specific fix direction]
     - 📎 관련 PR 코멘트: [if applicable]
 
+    💬 붙여넣기용 코멘트 ← "Paste-Ready Comment Blockquote" 섹션 참조 (📎로 confirms-existing이면 블록쿼트 대신 평문 노트)
+
 ## 🟡 P2 (차후 이슈 등록 권장)
 
 - **[category]** `파일:라인` 이슈 설명 — 리뷰어
     - **근거**: [severity justification]
     - 💡 수정 제안: [when non-obvious only]
 
+    💬 붙여넣기용 코멘트 ← "Paste-Ready Comment Blockquote" 섹션 참조 (`[제안]`은 💡 수정 제안이 있을 때만; 📎로 confirms-existing이면 평문 노트)
+
 ## 🟢 P3 (개선 제안)
 
-- **[category]** `파일:라인` 이슈 설명 — 리뷰어
-- **[category]** `파일:라인` 이슈 설명 — 리뷰어
+- **[category]** `파일:라인` [정중체·자기완결 한 줄 — 그대로 붙여넣을 수 있는 개선 제안] — 리뷰어
+- **[category]** `파일:라인` [정중체·자기완결 한 줄 — 줄 끝 `— 리뷰어명`은 복사 시 제외] — 리뷰어
 
 ---
 

--- a/plugins/cc-cmds/skills/review/references/03-non-pr-mode.md
+++ b/plugins/cc-cmds/skills/review/references/03-non-pr-mode.md
@@ -2,6 +2,8 @@
 
 When reviewing non-PR targets (local diff, file paths), adapt the context package and document header as below.
 
+**Paste-ready comments are still generated** in non-PR mode — the self-contained 정중체 blockquotes (see `02-review-report-template.md` "Paste-Ready Comment Blockquote") are portable to a future PR, a commit message, or an issue. The confirms-existing dedup exception does not apply here, since a fully independent review has no existing PR comments to defer to.
+
 ## Local diff mode
 
 | Element | PR Mode | Non-PR Mode (local diff) |


### PR DESCRIPTION
## 배경

`/cc-cmds:review` 리포트는 발견 항목을 단정체 분석(근거/제안)으로만 기술해, 사용자가 GitHub PR에 코멘트를 달려면 각 항목을 매번 손으로 정중체로 옮겨 적어야 했다. 이 보강을 리포트의 기본 산출물로 만들어, 리뷰가 끝나면 각 항목 아래에 그대로 붙여넣을 수 있는 자기완결적 코멘트가 자동으로 따라오게 한다.

## 변경 내용

- **P0~P2**: 분석 아래에 `💬 붙여넣기용 코멘트` 블록쿼트를 둔다. 라벨은 블록쿼트 밖 평문, `>`에는 본문(`P{N}: 재진술` + `[근거]` + `[제안]`)만 담아 블록쿼트만 복사하면 메타 라벨 오염 없이 게시할 수 있다. 제목은 산문만, 이슈 위치(`파일:라인`)는 `[근거]` 첫 언급에 두어 인라인·일반 PR 코멘트 양쪽에서 자기완결이다.
- **심각도별 규칙**: P0/P1은 근거·제안 필수, P2는 근거 필수에 `[제안]`은 분석에 `💡 수정 제안`이 있을 때만(분석에 없는 제안을 코멘트가 창작하지 않도록 게이팅), P3는 블록쿼트 없이 항목 한 줄이 곧 코멘트(줄 끝 `— 리뷰어명`은 복사 시 제외).
- **톤 이중성**: 분석 본문은 단정체, 코멘트는 정중체(확정 버그에 헤지 금지).
- **dedup 예외**: 기존 PR 코멘트를 확인만 하는 항목(`📎 관련 PR 코멘트` 보유)은 중복 코멘트 대신 한 줄 평문 노트만 둔다 — 블록쿼트 부재가 "새로 게시할 코멘트 없음" 신호다.
- **비-PR 모드**: 로컬 diff·파일 경로 리뷰에서도 코멘트는 그대로 생성(이식형: PR 개설·커밋 메시지·이슈에 이식 가능)되며, dedup 예외는 미적용이다.

코멘트는 Step 5에서 리드가 단독 작성하며, 리뷰어 산출 포맷과 컨텍스트 패키지(`01-reviewer-context-package.md`)는 무변경이다. 적용 범위는 `review` 한정(`review-lite` 제외).

## 변경 파일

- `references/02-review-report-template.md` — 신규 "Paste-Ready Comment Blockquote" 섹션 + Document Structure 코드블록(P0/P1/P2 앵커·P3 정중체 예시) + 개요 노트 1줄
- `SKILL.md` Step 5 — 코멘트 생성·톤·dedup·P3 규칙 문단 + 템플릿 Read 라인 갱신
- `references/03-non-pr-mode.md` — 비-PR 모드 이식형 코멘트 1줄
- `plugin.json` `1.11.0 → 1.12.0` + `CHANGELOG.md`

## 검증

- `make check` 통과 (lint + README 재생성 diff 0)