### PR TITLE
feat(review): 리뷰어 구성 강화 분석 스킬 review-upgrade 신설 + 두 축 코어 추출

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-06-04
+
+`/cc-cmds:review` Step 3 리뷰어 구성을 분석하는 **모델·역할 두 축 second-opinion 스킬 `review-upgrade`를 신설**한다. `design-upgrade`가 `/design` Step 2를 분석하는 것과 정확히 대칭으로, 직전 `/review` Step 3 구성에서 (a) opus 강점이 유의미한 리뷰어의 opus 승격, (b) 누락된 리뷰 관점을 메우는 신규 리뷰어 추가, (c) 과부하 리뷰어 분할을 짚어준다. 이를 위해 `design-upgrade`가 인라인으로 보유하던 두 축 강화 로직을 repo 최초의 **파라미터화된 `_common` 코어**(`_common/team-upgrade-analysis.md`)로 추출하고, `design-upgrade`를 그 소비자로 리팩터(동작 동등)한 뒤 `review-upgrade`를 두 번째 소비자로 얹는다. 이름·zero-arg·`disable-model-invocation: true`·"직전 제안이 컨텍스트에 있어야 동작"하는 성격과 "강화가 유의미할 때만 제안, 그 외엔 유지 사유"라는 절제 원칙을 `design-upgrade`와 대칭으로 보존한다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Added
+
+- **`review-upgrade` 신규 스킬**: `/review` Step 3 리뷰어 구성을 모델·역할 두 축으로 분석하는 `disable-model-invocation: true` zero-arg second-opinion. 역할 축은 미커버 **리뷰 관점**(security/performance/code-quality/logic/error-handling/type-safety/testing/api-contract/concurrency/data-integrity)을 대상으로 하며, Step 3의 risk-indicator→reviewer 매핑(auth→security, DB→perf/DB, public-API→API-contract, external→security+integration, async→concurrency)을 커버리지 계약으로 화해해 ADD를 4조건 ALL 충족 시에만 발화한다(diff 신호 + 누구도 미소유 + 발화된 indicator로 미라우팅 + 기존 체크리스트 미흡수). 과부하 리뷰어 SPLIT은 정량 증거(파일수·diff 크기)로 게이팅하며 `PARTITION` 무손실·무중복 계약을 둔다. OPERATION 태그(UPGRADE/ADD/SPLIT-REPLACE[/ADD-Coordinator])는 `역할 | 모델 | 담당 범위` 순서로 emit해 `/review` 재제안 입력으로 모호함 없이 paste-back된다. precondition 부재 시 3-path fallback: (1) 세션 로스터 붙여넣기→완전 두 축(재투입=Step 3 재제안), (2) 저장 리뷰 리포트 역산→모델 UPGRADE·관점 ADD 복원하되 정량 SPLIT·ADD-Coordinator는 suppress(재투입=Step 6 팀 재생성, augmented 필드로 매핑), (3) 둘 다 없으면 한국어 안내 후 종료.
+- **`_common/team-upgrade-analysis.md` 파라미터화된 코어**: repo 최초의 파라미터화된 `_common` 파일. 축-불문 두 축 알고리즘(Scope·절제 원칙·4단계 역할-갭 탐지·HARD LIMIT·절제 게이트·분할 게이트·OPERATION 구조·기존-역할당 OPERATION 1개 불변식·교차축 synthesis·degraded-axis 처리)을 리터럴 `{PLACEHOLDER}` + 3-채널 주입 인터페이스(`## Bindings` 값 치환 / `## Operations Layer` 규칙 append seam / 주입 prose)로 담는다. 기존 self-contained `_common`과 달리 소비 스킬의 `## Bindings`로 placeholder를 resolve해야 구체 계약이 된다.
+
+### Changed
+
+- **`design-upgrade/SKILL.md` 코어 소비로 리팩터**: 인라인 두 축 로직을 코어 self-read + `## Bindings`(design 값)로 치환하고, 주입 prose(Precondition/design-lite 가드/sync-note/3-path Fallback)는 유지한다. frontmatter 불변(README row byte-동일) + 8개 결정 동작 동등. Path 2의 모델축 N/A 처리는 `{MODEL_AXIS_DEGRADES_UNDER}` 바인딩 경유로 코어 split gate·Cross-axis synthesis가 인지한다.
+- **`review-lite/SKILL.md` reciprocal 상호참조**: sonnet-pin Constraints bullet에 review-upgrade의 두 축이 review-lite에서 out of scope이며 base `/cc-cmds:review`에 대해 `/cc-cmds:review-upgrade`를 쓰라는 out-of-scope 명확화 1줄을 추가(redirect 아님, design-lite의 design-upgrade 상호참조 미러). frontmatter 불변→README row 불변.
+- **`scripts/lint-skill-invariants.sh` EXEMPT 확장**: `EXEMPT_SKILLS` 배열에 `review-upgrade`를 추가(single-pass·무팀·무카운터 second-opinion, design-upgrade와 동일 근거)하고 근거 doc-comment 인벤토리도 갱신한다(behavioral 무영향).
+
 ## [1.12.0] - 2026-06-04
 
 `/cc-cmds:review` 리포트가 각 발견 항목 아래에 **GitHub에 그대로 붙여넣을 수 있는 정중체 코멘트를 기본 산출**하도록 확장한다. 지금까지는 발견 항목을 단정체 분석(근거/제안)으로만 기술해, 사용자가 PR에 코멘트를 달려면 매번 손으로 정중체로 옮겨 적어야 했다. 이제 P0~P2 항목은 분석 바로 아래에 `💬 붙여넣기용 코멘트` 블록쿼트를, P3 항목은 항목 한 줄 자체를 정중체·자기완결로 작성해 복사-붙여넣기만으로 인라인 코멘트를 게시할 수 있다. 코멘트는 Step 5에서 리드가 단독 작성하며(리뷰어 산출 포맷·컨텍스트 패키지는 무변경), 적용 범위는 `review` 한정(`review-lite` 제외) (`/plugin update cc-cmds`로 자동 반영).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Engineering workflow commands for Claude Code.
 | `/cc-cmds:implement` | 설계 문서 기반 구현 | 사용자가 작성된 설계 문서를 바탕으로 단계적 계획을 세우고 실제 구현을 수행하기를 원할 때 |
 | `/cc-cmds:review` | 에이전트 팀을 활용한 다관점 코드 리뷰 | 사용자가 PR/로컬 diff/파일 경로에 대한 다관점 코드 리뷰(보안/성능/품질 등)를 요청할 때 |
 | `/cc-cmds:review-lite` | 2인 팀을 활용한 경량 코드 리뷰 | 빠른 코드 리뷰가 목적이고 다관점 심층 분석이 불필요할 때 (큰 PR coverage gap, 미묘한 race condition·authn bypass 검출률 약화 가능) |
+| `/cc-cmds:review-upgrade` | 리뷰어 구성 강화 분석 (모델·역할 축) | 직전 `/review` Step 3 리뷰어 구성 제안에서 opus 승격이 유의미한 역할이 있는지, 누락된 리뷰 관점을 메울 신규 리뷰어 추가가 필요한지, 또는 과부하 리뷰어 분할이 필요한지 second-opinion으로 검토할 때 |
 
 <!-- SKILLS_TABLE_END -->
 
@@ -133,6 +134,7 @@ npx skills add https://github.com/vercel-labs/agent-skills --skill web-design-gu
 - [/cc-cmds:implement](#cc-cmdsimplement)
 - [/cc-cmds:review](#cc-cmdsreview)
 - [/cc-cmds:review-lite](#cc-cmdsreview-lite)
+- [/cc-cmds:review-upgrade](#cc-cmdsreview-upgrade)
 
 ### /cc-cmds:design
 
@@ -272,6 +274,12 @@ _이 커맨드는 별도 인자를 받지 않으며, 직전 `/design` 팀 구성
 | Option | Default | Summary |
 | --- | --- | --- |
 | `<target>` | _(optional)_ | 리뷰 대상 (PR 번호/URL, 브랜치, 파일/디렉토리, 또는 생략 시 현재 브랜치 자동 감지). PR 크기 무관 — 큰 PR 은 report 의 *리뷰 범위* 섹션에 미커버 영역 명시. |
+
+### /cc-cmds:review-upgrade
+
+**Usage**: `/cc-cmds:review-upgrade`
+
+_이 커맨드는 별도 인자를 받지 않으며, 직전 `/review` Step 3 리뷰어 구성 제안이 현재 대화 컨텍스트에 있어야 동작한다. opus 승격, 누락 리뷰 관점 추가, 과부하 리뷰어 분할은 강화가 유의미할 때만 제안하며, 그 외에는 유지 사유를 제시한다. 독립 실행 시 결과가 불정확할 수 있다._
 
 <!-- SKILLS_OPTIONS_END -->
 

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/_common/team-upgrade-analysis.md
+++ b/plugins/cc-cmds/skills/_common/team-upgrade-analysis.md
@@ -1,0 +1,125 @@
+# Team-Upgrade Analysis (Shared Parameterized Core)
+
+Axis-agnostic engine for a **two-axis** (model + role) second-opinion on a team composition proposed by an upstream skill step. A consuming skill (`design-upgrade`, `review-upgrade`) reads this file and specializes it through three injection channels (see **Injection Interface** below). Restraint is the default: `역할 변경 불필요` / `모델 변경 불필요` (no change needed) is a valid and expected outcome on either axis.
+
+This file is **parameterized** — it contains literal `{PLACEHOLDER}` tokens that the consuming skill resolves via its own `## Bindings` section. Unlike the self-contained `_common` files (e.g. `agent-team-protocol.md`) that are read wholesale, a reader of this core must resolve the placeholders against the consuming skill's `## Bindings` to obtain the concrete contract.
+
+## Injection Interface
+
+A consuming skill specializes this core through exactly three channels:
+
+1. **`## Bindings`** (value substitution) — the consuming skill resolves every `{PLACEHOLDER}` token below to a concrete *value* (labels, field order, anchor objects, source-step, model-axis availability flag, re-feed target, etc.). Pure value resolution, no rule changes.
+2. **`## Operations Layer`** (rule append seam) — the consuming skill MAY (a) declare additional OPERATION classes that carry their own gate, and (b) append to this core's forbidden-set. This is prose-rule append, not token substitution. **Open for extension**: a consuming skill may define an additional OPERATION class provided it is reinforcement-direction, declares its own gate, and respects the per-existing-role invariant below; and it may append entries to this core's forbidden-set.
+3. **Injected prose sections** — `frontmatter`, the Fallback section, the lite-guard paragraph, and the schema-drift sync-note are authored entirely per-skill in the consuming SKILL.md and are NOT part of this core.
+
+## Placeholders (resolved by the consuming skill's `## Bindings`)
+
+- `{SCOPE_LABEL}` — the Korean label for a role's coverage/exploration scope field.
+- `{FIELD_ORDER}` — the emit order of the role triple's Korean fields.
+- `{SOURCE_STEP}` — the upstream step that produced the team composition under analysis.
+- `{ROSTER_SOT}` — where the roster source-of-truth lives (and its language/format).
+- `{LABEL_RELATION}` — how the OPERATION Korean labels relate to the source roster (conceptual translation vs verbatim-equal).
+- `{ROLE_GAP_ANCHOR}` — a skill-specific anchor describing what counts as an uncovered gap (may be empty).
+- `{RE_EXPLORATION_ANCHOR}` — the in-context objects the lightweight re-exploration anchors on.
+- `{LITE_GUARD_TARGET}` — the sibling lite skill whose fixed roster the lite-guard protects.
+- `{PRECONDITION}` — the precondition that the source-step composition is in context.
+- `{MODEL_AXIS_DEGRADES_UNDER}` — the active input path under which the model axis becomes unavailable (or `never`).
+- `{SAVED_DOC_LOCATION}` — the saved-document path used by the reverse-engineer fallback path.
+- `{REFEED_TARGET}` — where an emitted OPERATION set is re-fed (may be path-conditional).
+
+---
+
+Analyze the team composition proposed in the preceding `{SOURCE_STEP}` output and produce a second opinion along **two axes** — model and role — recommending only *reinforcing* changes. Restraint is the default on both axes.
+
+## Scope
+
+Two analysis axes, reinforcement-direction only:
+
+- **Model axis**: among teammates assigned `haiku`/`sonnet`, identify those where opus's strengths — complex reasoning, cross-domain analysis, deep code analysis — would make a meaningful difference, and propose promotion to opus.
+- **Role axis**: (a) **ADD** a new role for an in-scope domain that no current teammate owns, or (b) **SPLIT-REPLACE** one overloaded broad role into two.
+
+**Out of scope — never propose**: role removal, role merge, model downgrade. (A consuming skill's `## Operations Layer` may append further forbidden entries.)
+
+**Restraint principle (most important)**: just as model promotion is proposed only when it makes a meaningful difference, role ADD/SPLIT is proposed only when needed — not always. "변경 불필요" is the default and a normal output on both axes; mirror the model-axis retain-rationale symmetry onto the role axis.
+
+## Evaluation criteria
+
+### Role-gap detection (single pass)
+
+Four-step coverage diff: enumerate domains → build a coverage map → flag uncovered domains → apply the restraint gate (most candidates drop here). This is a **single pass** — no iterate-until loop and no termination contract. {ROLE_GAP_ANCHOR}
+
+Lightweight re-exploration (read-only; no team, no writes, no test/build, no MCP): grep/ls limited to surfaces the proposal already named — anchored on {RE_EXPLORATION_ANCHOR} — and their adjacent sibling directories, plus single-file Read ≤200 lines.
+
+**HARD LIMIT**:
+
+1. ≤12 total read-only operations/calls; on exhaustion, stop (uncharacterized domains default to no change).
+2. A single grep with >50 hits is inconclusive for ADD — treat it as an already-central domain, not gap evidence (bias to no change). This bias applies **only to new-domain discovery (ADD)**; the same large hit can serve as overload input for a SPLIT candidate under the split gate, so do NOT silence SPLIT reasoning at the grep step.
+3. make/test/build, team spawn, MCP, and writes are fully prohibited.
+4. Re-exploration is confirmatory — confirm only gaps the proposal already implied; do not fish for new out-of-scope domains. Inconclusive → bias to "no change".
+
+### Restraint gate (new role — ALL required)
+
+1. A specific uncovered domain that no role owns (cite path / requirement).
+2. ≥1 consequential, non-mechanical decision living in that domain.
+3. Distinct expertise an existing role would not naturally produce within its scope.
+
+If any fails → no new role. Expanding an existing role's scope (absorption) is out of scope, so a confirmed gap is handled as a **new role**, not a scope edit.
+
+### Split gate (ALL required)
+
+1. The scope spans two separable domain clusters, each with independent decisions (aligned with the 1→2 partition contract below — if 3+ distinct domains, split only the single strongest cleavage this round and defer the residual overload to the next re-proposal round).
+2. Depth contention — one teammate would starve one side.
+3. Clean cleavage — no shared core forcing constant cross-talk.
+4. Cross-axis reconciliation — explicitly compare SPLIT (two sonnets, parallel focus, +coordination cost, +1 headcount) vs UPGRADE (one opus spanning both, single synthesis preserved), then pick one.
+
+### Degraded-axis handling
+
+If the model axis is unavailable on the active input path — see `{MODEL_AXIS_DEGRADES_UNDER}` — the split gate's cross-axis reconciliation (step 4) and the Cross-axis synthesis below treat the UPGRADE comparison term as N/A and proceed on the role axis alone (skip the SPLIT-vs-UPGRADE weighing). When `{MODEL_AXIS_DEGRADES_UNDER}` is `never`, this is dead code.
+
+Symmetrically, a consuming skill's injected prose MAY declare that the **SPLIT comparison term** is N/A on some active path (e.g. when quantitative overload signal is absent). In that case the split gate's step 4 and the Cross-axis synthesis treat the SPLIT term as N/A and fall through to the UPGRADE-parent alone. Either axis's degradation is routed into the same two gate/synthesis sites so neither is left undefined when one comparison term drops out.
+
+## Output format
+
+Every recommendation carries an explicit OPERATION tag so the user or the next-turn model can re-feed it into {REFEED_TARGET} without ambiguity (there is no ingestion path that auto-applies these tags). Field labels are Korean — `역할` / `{SCOPE_LABEL}` / `모델` — and their relation to the source roster ({ROSTER_SOT}) is {LABEL_RELATION}; only the model-value aliases `"opus"` / `"sonnet"` / `"haiku"` are tokens shared verbatim across both sides. OPERATIONs that emit a full role triple do so in the order `{FIELD_ORDER}`.
+
+### `UPGRADE` (existing teammate, model axis)
+
+- `역할` — must match an existing roster role name (lookup key). Comparison is exact string match after trimming leading/trailing whitespace; any other drift (case, parenthetical-note differences, etc.) is malformed → re-confirm with the user. Never silently create a new entry.
+- `현재 모델 → 권장 모델`
+- 변경 사유
+- 기대 효과
+
+Omit `{SCOPE_LABEL}` — only the model cell changes, so restating the unchanged scope is noise and a stale-copy risk. (Scope is omitted, so the field-order rule does not apply to UPGRADE.)
+
+### `ADD` (new role)
+
+- Full role triple in the order `{FIELD_ORDER}`
+- 근거 (the uncovered domain)
+- 기대 효과
+
+The new `역할` name must not collide with any existing roster role name — a collision means this is a scope-expansion attempt on an existing role, which is out of scope (fails the restraint gate). Symmetric with UPGRADE's lookup-key integrity.
+
+### `SPLIT-REPLACE` (overloaded parent role → two children, parent removed)
+
+- Each of the two children: a full role triple in the order `{FIELD_ORDER}`
+- `PARTITION: childA.{SCOPE_LABEL} ⊎ childB.{SCOPE_LABEL} = parent.{SCOPE_LABEL} (no overlap, no loss)`
+- 근거 (overload evidence)
+- 기대 효과
+
+A SPLIT-REPLACE making the parent role name disappear is NOT the forbidden "removal" — it is a reinforcing 1→2 split. Tag it `SPLIT-REPLACE`, not `REMOVE`, so the re-proposal does not misread it as a downgrade.
+
+### Invariant — at most one OPERATION per existing role
+
+A single parent role must not carry both `UPGRADE` and `SPLIT-REPLACE`. If both seem valid, pick the stronger one and state the tradeoff. `ADD` does not touch existing roles, so it combines freely. (A consuming skill's `## Operations Layer` OPERATION class that mints a brand-new role is likewise exempt from this per-existing-role invariant.)
+
+### Shared Korean emit vocabulary
+
+`현재 모델 → 권장 모델` · `변경 사유` / `유지 사유` · `기대 효과` · `역할 변경 불필요` / `모델 변경 불필요` · `근거`. Model-value aliases `opus` / `sonnet` / `haiku` are shared verbatim. The skill body text and headings are English; only these emit fields and user-facing notices are Korean.
+
+## Cross-axis synthesis
+
+Weigh both axes together. When the same weakness is targeted by both a model promotion and a role change, choose only the stronger side and state the tradeoff explicitly (e.g., "promote teammate X to opus" vs "add a new opus role dedicated to domain Y"). Honor the Degraded-axis handling above when either comparison term is N/A on the active path.
+
+## Schema-drift sync-note template (one-directional, per consuming skill)
+
+Each consuming skill injects its own sync-note of the form: the source of truth is `{ROSTER_SOT}`'s team-composition field set; if that field set changes, manually sync this skill's OPERATION Korean labels and model aliases (the Korean labels are this skill's emit surface, related to the source fields as {LABEL_RELATION}). Do NOT touch the source skill. The residual risk of a missed sync is accepted without a lint. Each sync-note is single-direction (one per (consumer, source-step) pair) with no cross-coupling.

--- a/plugins/cc-cmds/skills/design-upgrade/SKILL.md
+++ b/plugins/cc-cmds/skills/design-upgrade/SKILL.md
@@ -9,86 +9,28 @@ notes: |
     이 커맨드는 별도 인자를 받지 않으며, 직전 `/design` 팀 구성 제안이 현재 대화 컨텍스트에 있어야 동작한다. 모델 승격과 역할 추가·분할은 강화가 유의미할 때만 제안하며, 그 외에는 유지 사유를 제시한다. 독립 실행 시 결과가 불정확할 수 있다.
 ---
 
-Analyze the team composition proposed in the preceding `/design` Step 2 output and produce a second opinion along **two axes** — model and role — recommending only *reinforcing* changes. Restraint is the default: `역할 변경 불필요` / `모델 변경 불필요` (no change needed) is a valid and expected outcome on either axis.
+Analyze the team composition proposed in the preceding `/design` Step 2 output and produce a second opinion along **two axes** — model and role — recommending only *reinforcing* changes.
 
-## Scope
+**Read `${CLAUDE_SKILL_DIR}/../_common/team-upgrade-analysis.md`** for the axis-agnostic engine: the two-axis Scope, restraint principle, role-gap detection + HARD LIMIT, restraint/split gates, OPERATION output format and integrity rules, the per-existing-role invariant, the degraded-axis handling, and the Cross-axis synthesis. Resolve every `{PLACEHOLDER}` in that core against the `## Bindings` below. The Precondition, design-lite conflict guard, schema-drift sync-note, and 3-path Fallback that follow are this skill's injected prose.
 
-Two analysis axes, reinforcement-direction only:
+## Bindings
 
-- **Model axis** (existing behavior): among teammates assigned `haiku`/`sonnet`, identify those where opus's strengths — complex reasoning, cross-domain analysis, deep code analysis — would make a meaningful difference, and propose promotion to opus.
-- **Role axis** (new): (a) **ADD** a new role for an in-design-scope domain that no current teammate owns, or (b) **SPLIT-REPLACE** one overloaded broad role into two.
+| Placeholder | Value |
+| --- | --- |
+| `{SCOPE_LABEL}` | `탐색 범위` |
+| `{FIELD_ORDER}` | `역할 / 탐색 범위 / 모델` |
+| `{SOURCE_STEP}` | `/design` Step 2 |
+| `{ROSTER_SOT}` | `design/SKILL.md` Step 2 (English prose: role / exploration scope / model, plus the model-alias set) |
+| `{LABEL_RELATION}` | conceptual translation (the Korean OPERATION labels conceptually correspond to Step 2's English-prose fields) |
+| `{ROLE_GAP_ANCHOR}` | *(empty — no skill-specific gap anchor)* |
+| `{RE_EXPLORATION_ANCHOR}` | the interview / task narrative |
+| `{LITE_GUARD_TARGET}` | design-lite |
+| `{PRECONDITION}` | the preceding `/design` Step 2 team composition is in context |
+| `{MODEL_AXIS_DEGRADES_UNDER}` | Fallback Path 2 |
+| `{SAVED_DOC_LOCATION}` | `docs/<slug>.md` |
+| `{REFEED_TARGET}` | `/design` Step 2 re-proposal (same target on every path) |
 
-**Out of scope — never propose**: role removal, role merge, model downgrade.
-
-**Restraint principle (most important)**: just as model promotion is proposed only when it makes a meaningful difference, role ADD/SPLIT is proposed only when needed — not always. "변경 불필요" is the default and a normal output on both axes; mirror the existing retain-rationale symmetry onto the role axis.
-
-## Evaluation criteria
-
-### Role-gap detection (single pass)
-
-Four-step coverage diff: enumerate domains → build a coverage map → flag uncovered domains → apply the restraint gate (most candidates drop here). This is a **single pass** — no iterate-until loop and no termination contract.
-
-Lightweight re-exploration (read-only; no team, no writes, no test/build, no MCP): grep/ls limited to surfaces the proposal/interview already named and their adjacent sibling directories, plus single-file Read ≤200 lines.
-
-**HARD LIMIT**:
-
-1. ≤12 total read-only operations/calls; on exhaustion, stop (uncharacterized domains default to no change).
-2. A single grep with >50 hits is inconclusive for ADD — treat it as an already-central domain, not gap evidence (bias to no change). This bias applies **only to new-domain discovery (ADD)**; the same large hit can serve as overload input for a SPLIT candidate under the split gate, so do NOT silence SPLIT reasoning at the grep step.
-3. make/test/build, team spawn, MCP, and writes are fully prohibited.
-4. Re-exploration is confirmatory — confirm only gaps the interview/task already implied; do not fish for new out-of-scope domains. Inconclusive → bias to "no change".
-
-### Restraint gate (new role — ALL required)
-
-1. A specific uncovered domain that no role owns (cite path / requirement).
-2. ≥1 consequential, non-mechanical design decision living in that domain.
-3. Distinct expertise an existing role would not naturally produce within its scope.
-
-If any fails → no new role. Expanding an existing role's scope (absorption) is out of scope, so a confirmed gap is handled as a **new role**, not a scope edit.
-
-### Split gate (ALL required)
-
-1. The scope spans two separable domain clusters, each with independent decisions (aligned with the 1→2 partition contract below — if 3+ distinct domains, split only the single strongest cleavage this round and defer the residual overload to the next re-proposal round).
-2. Depth contention — one teammate would starve one side.
-3. Clean cleavage — no shared core forcing constant cross-talk.
-4. Cross-axis reconciliation — explicitly compare SPLIT (two sonnets, parallel focus, +coordination cost, +1 headcount) vs UPGRADE (one opus spanning both, single synthesis preserved), then pick one.
-
-## Output format
-
-Every recommendation carries an explicit OPERATION tag so the user or the next-turn model can re-feed it into `/design` Step 2 re-proposal without ambiguity (there is no ingestion path that auto-applies these tags). Field labels are Korean — `역할` / `탐색 범위` / `모델` — conceptually aligned with Step 2's English-prose fields (role / exploration scope / model); only the model-value aliases `"opus"` / `"sonnet"` / `"haiku"` are tokens shared verbatim across both sides.
-
-### `UPGRADE` (existing teammate, model axis)
-
-- `역할` — must match an existing roster role name (lookup key). Comparison is exact string match after trimming leading/trailing whitespace; any other drift (case, parenthetical-note differences, etc.) is malformed → re-confirm with the user. Never silently create a new entry.
-- `현재 모델 → 권장 모델`
-- 변경 사유
-- 기대 효과
-
-Omit `탐색 범위` — only the model cell changes, so restating the unchanged scope is noise and a stale-copy risk.
-
-### `ADD` (new role)
-
-- Full `역할 / 탐색 범위 / 모델` for one item
-- 근거 (the uncovered domain)
-- 기대 효과
-
-The new `역할` name must not collide with any existing roster role name — a collision means this is a scope-expansion attempt on an existing role, which is out of scope (fails the restraint gate). Symmetric with UPGRADE's lookup-key integrity.
-
-### `SPLIT-REPLACE` (overloaded parent role → two children, parent removed)
-
-- Each of the two children: `역할 / 탐색 범위 / 모델`
-- `PARTITION: childA.탐색 범위 ⊎ childB.탐색 범위 = parent.탐색 범위 (no overlap, no loss)`
-- 근거 (overload evidence)
-- 기대 효과
-
-A SPLIT-REPLACE making the parent role name disappear is NOT the forbidden "removal" — it is a reinforcing 1→2 split. Tag it `SPLIT-REPLACE`, not `REMOVE`, so the re-proposal does not misread it as a downgrade.
-
-### Invariant — at most one OPERATION per existing role
-
-A single parent role must not carry both `UPGRADE` and `SPLIT-REPLACE`. If both seem valid, pick the stronger one and state the tradeoff. `ADD` does not touch existing roles, so it combines freely.
-
-## Cross-axis synthesis
-
-Weigh both axes together. When the same weakness is targeted by both a model promotion and a role change, choose only the stronger side and state the tradeoff explicitly (e.g., "promote teammate X to opus" vs "add a new opus role dedicated to domain Y").
+This skill declares no `## Operations Layer` — it uses the core's OPERATION set (UPGRADE / ADD / SPLIT-REPLACE) and forbidden-set unchanged.
 
 ## Precondition
 
@@ -103,5 +45,5 @@ This skill requires the preceding `/design` Step 2 team composition to be in con
 When the precondition is not met, follow a 3-path fallback:
 
 - **Path 1 — session roster paste**: the user pastes the Step 2 composition → full two-axis analysis.
-- **Path 2 — reverse-engineer from a saved design doc (degraded — role axis only)**: `docs/<slug>.md` captures architecture/scope but does NOT save the Step 2 roster (Step 4 saves only architecture / decisions / issues / order). Role-gap detection is possible from the doc's scope, but the model axis is not (no current model assignments). State this limitation when taking this path. Because the model axis is impossible at the source, the split gate's cross-axis reconciliation and the Cross-axis synthesis treat the UPGRADE comparison term as N/A and proceed on the role axis alone (skip the SPLIT-vs-UPGRADE tradeoff weighing). Also, since no interview is in session, the lightweight re-exploration anchor is the saved doc's architecture/scope narrative instead of the interview — limit to surfaces the doc cites/names and their adjacent siblings under the same HARD LIMIT.
+- **Path 2 — reverse-engineer from a saved design doc (degraded — role axis only)**: `docs/<slug>.md` captures architecture/scope but does NOT save the Step 2 roster (Step 4 saves only architecture / decisions / issues / order). Role-gap detection is possible from the doc's scope, but the model axis is not (no current model assignments). State this limitation when taking this path. Because the model axis is impossible at the source, the core's degraded-axis handling fires here (`{MODEL_AXIS_DEGRADES_UNDER}` = Fallback Path 2): the split gate's cross-axis reconciliation and the Cross-axis synthesis treat the UPGRADE comparison term as N/A and proceed on the role axis alone (skip the SPLIT-vs-UPGRADE tradeoff weighing). Also, since no interview is in session, the lightweight re-exploration anchor is the saved doc's architecture/scope narrative instead of the interview — limit to surfaces the doc cites/names and their adjacent siblings under the same HARD LIMIT.
 - **Path 3 — start a new `/design`**: when neither is available, two-axis analysis is impossible — emit a Korean notice (e.g., *"분석할 팀 구성이 없습니다. 먼저 `/cc-cmds:design`을 실행해 팀 구성을 받은 뒤 다시 호출하세요."*) and stop.

--- a/plugins/cc-cmds/skills/review-lite/SKILL.md
+++ b/plugins/cc-cmds/skills/review-lite/SKILL.md
@@ -262,7 +262,7 @@ Repeat until user is satisfied.
 
 - **No code modifications.** Review only.
 - **Inter-agent communication must be in English.** User-facing communication and saved documents in Korean.
-- **Sonnet pin**: every reviewer uses model `"sonnet"`. Haiku is forbidden; opus is out of scope (use `/cc-cmds:review` if opus depth is required).
+- **Sonnet pin**: every reviewer uses model `"sonnet"`. Haiku is forbidden; opus is out of scope (use `/cc-cmds:review` if opus depth is required). Both of `/cc-cmds:review-upgrade`'s reinforcement axes are out of scope here — opus upgrade violates the sonnet pin, and reviewer add/split (and the Scope Coordinator add) mutates the fixed 2-member roster (run `/cc-cmds:review-upgrade` against a base `/cc-cmds:review` run instead).
 - **Agent Team required**: TeamCreate + SendMessage only. Do NOT substitute with isolated Agent sub-agents.
 - **Deferred tool loading**: Before using AskUserQuestion, TeamCreate, SendMessage, or TeamDelete, you MUST first load them via ToolSearch. AskUserQuestion MUST be loaded before Step 1.
 - **No Claude Context MCP**: do NOT call `index_codebase`, `get_indexing_status`, or `search_code`. Use `grep` + `Read` only.

--- a/plugins/cc-cmds/skills/review-upgrade/SKILL.md
+++ b/plugins/cc-cmds/skills/review-upgrade/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: review-upgrade
+description: 리뷰어 구성 강화 분석 (모델·역할 축)
+when_to_use: 직전 `/review` Step 3 리뷰어 구성 제안에서 opus 승격이 유의미한 역할이 있는지, 누락된 리뷰 관점을 메울 신규 리뷰어 추가가 필요한지, 또는 과부하 리뷰어 분할이 필요한지 second-opinion으로 검토할 때
+disable-model-invocation: true
+usage: "/cc-cmds:review-upgrade"
+options: []
+notes: |
+    이 커맨드는 별도 인자를 받지 않으며, 직전 `/review` Step 3 리뷰어 구성 제안이 현재 대화 컨텍스트에 있어야 동작한다. opus 승격, 누락 리뷰 관점 추가, 과부하 리뷰어 분할은 강화가 유의미할 때만 제안하며, 그 외에는 유지 사유를 제시한다. 독립 실행 시 결과가 불정확할 수 있다.
+---
+
+Analyze the reviewer team composition proposed in the preceding `/review` Step 3 output and produce a second opinion along **two axes** — model and role — recommending only *reinforcing* changes.
+
+**Read `${CLAUDE_SKILL_DIR}/../_common/team-upgrade-analysis.md`** for the axis-agnostic engine: the two-axis Scope, restraint principle, role-gap detection + HARD LIMIT, restraint/split gates, OPERATION output format and integrity rules, the per-existing-role invariant, the degraded-axis handling, and the Cross-axis synthesis. Resolve every `{PLACEHOLDER}` in that core against the `## Bindings` below. The `## Operations Layer`, role-axis mapping, SPLIT-axis degradation, Precondition, review-lite conflict guard, schema-drift sync-note, and 3-path Fallback that follow are this skill's injected layers.
+
+## Bindings
+
+| Placeholder | Value |
+| --- | --- |
+| `{SCOPE_LABEL}` | `담당 범위` |
+| `{FIELD_ORDER}` | `역할 / 모델 / 담당 범위` |
+| `{SOURCE_STEP}` | `/review` Step 3 |
+| `{ROSTER_SOT}` | `/review` Step 3 (Korean table: `역할 | 모델 | 담당 범위`) |
+| `{LABEL_RELATION}` | verbatim-equal (the OPERATION Korean labels equal the Step 3 table headers verbatim) |
+| `{ROLE_GAP_ANCHOR}` | A gap is a review perspective the Step 3 risk-indicator table missed — see Role-axis mapping below. |
+| `{RE_EXPLORATION_ANCHOR}` | the PR diff + changed-file set + risk-indicator table |
+| `{LITE_GUARD_TARGET}` | review-lite (sonnet pin) |
+| `{PRECONDITION}` | the preceding `/review` Step 3 reviewer composition is in context |
+| `{MODEL_AXIS_DEGRADES_UNDER}` | never (the saved report preserves each reviewer's model) |
+| `{SAVED_DOC_LOCATION}` | `docs/reviews/<report>.md` |
+| `{REFEED_TARGET}` | live / Path-1 → `/review` Step 3 re-proposal (prospective); Path-2 → `/review` Step 6 team re-creation (retrospective) |
+
+Note the column order differs from design-upgrade: Step 3's schema places **모델 before 담당 범위**. `역할` / `모델` are shared tokens; `담당 범위` substitutes design's `탐색 범위`. The full-triple OPERATIONs (ADD, SPLIT-REPLACE) emit in `역할 / 모델 / 담당 범위` order for paste-back parity; UPGRADE omits scope, so order is unaffected.
+
+## Operations Layer
+
+This skill extends the core with one additional OPERATION class and one forbidden-set entry.
+
+### `ADD-Coordinator` (review-only OPERATION)
+
+The `/review` Scope Coordinator (a >50-file PR meta/orchestration role: Round 0 file-risk classification + per-round coverage audit + cross-cutting issue synthesis) is **not a domain perspective**, so it cannot pass the core's 3-condition restraint gate. It is therefore declared here, outside the core, as a reinforcement-direction OPERATION with its own gate.
+
+**2-condition structural gate (bypasses the restraint gate)** — BOTH required:
+
+1. The confirmed scope exceeds 50 files — measured against the **Step 1c-narrowed** scope (if the user chose "특정 경로만" / "리뷰 분할", the effective scope may be ≤50, in which case this fails).
+2. No Step 3 role performs the coordinator function.
+
+**Invariant interaction**: ADD-Coordinator mints a brand-new role → exempt from the per-existing-role invariant, combines freely. Carryover guard: (a) the new coordinator name must not collide with any existing roster role, (b) gate condition (2) already enforces at most one coordinator per proposal.
+
+**Coordinator-targeting OPERATION rules**: `UPGRADE`-Coordinator is **valid** (an existing sonnet coordinator → opus; cross-cutting synthesis is exactly an opus strength) — this needs no separate op, the shared `UPGRADE` targets the coordinator role. ADD-Coordinator (when absent) and UPGRADE-Coordinator (when present) are mutually exclusive by precondition, so the per-existing-role invariant stays cleanly satisfied.
+
+**Path-2 suppress**: gate condition (1)'s Step 1c-narrowed effective scope is not preserved in the saved report (the report `## 개요` holds only the raw `변경 규모: 파일 X개`, not the post-1c effective scope). Therefore **ADD-Coordinator is not emitted on Path-2 (suppressed)** — same Path-2 quantitative-signal absence as the SPLIT degradation below. Falling back to raw `변경 규모` risks misjudging the effective scope, so it is not adopted (honesty first; state the caveat).
+
+### Forbidden-set append
+
+- `SPLIT-REPLACE`-Coordinator is **forbidden** (splitting a unified cross-cutting synthesis role constructively violates clean cleavage). This appends to the core's forbidden-set (role removal / merge / model downgrade).
+
+## Role-axis mapping (review)
+
+The core's role axis here means **uncovered review perspective**, drawn from: security / performance / code-quality / logic / error-handling / type-safety / testing / api-contract / concurrency / data-integrity.
+
+**Risk-indicator reconciliation rule (the heart of the restraint)**: Step 3's risk-indicator → reviewer mapping (auth→security, DB→perf/DB, public-API→API-contract, external→security+integration, async→concurrency) is Step 3's own coverage contract. An `ADD` fires only when ALL hold:
+
+- (a) the diff shows a signal for that perspective,
+- (b) none of the Step 3 proposal's `담당 범위` owns that perspective,
+- (c) it is not already routed by a *fired* risk-indicator mapping,
+- (d) it is not already absorbed into an existing reviewer's role-specific checklist.
+
+Because those checklists are broad, the restraint gate's distinct-expertise bar (condition 3) is high and most candidates drop at (c)/(d). The canonical valid `ADD`: Step 3 misclassified the PR type so an indicator that *should* have fired did not, leaving a perspective (e.g. DB migration → data-integrity) genuinely uncovered.
+
+**SPLIT-over-`담당 범위`**: fires when a single `담당 범위` spans two separable perspectives and this PR's volume would starve one side. The overload evidence here is **quantitative** (file count + diff size of the parent perspective's slice, from the in-context per-file statistics) — this is where the core HARD LIMIT item 2 ("a large hit is SPLIT input") applies. PARTITION: `childA.담당 범위 ⊎ childB.담당 범위 = parent.담당 범위 (no overlap, no loss)`. The split gate's step-4 cross-axis reconciliation chooses between SPLIT (two sonnets, parallel focus, +coordination, +1 headcount) and UPGRADE (promote the parent to opus, single synthesis preserved).
+
+## SPLIT-axis degradation (review Path-2)
+
+The SPLIT overload evidence (quantitative per-file statistics) is in context only on live / Path-1. **On Path-2 (saved-report reverse-engineering), per-file diff statistics are absent → quantitative SPLIT gating degrades to N/A (suppressed)** — the mirror image of design's model-axis N/A. Concretely, this is the core's "consuming skill MAY declare the SPLIT comparison term N/A" hook: on Path-2 the core split gate's step 4 and the Cross-axis synthesis treat the **SPLIT comparison term** as N/A and fall through to the UPGRADE-parent alone (exactly symmetric to proceeding on the role axis alone when the model term is N/A). So on Path-2 only `ADD` (perspective gap) + `UPGRADE` (model) fire; `SPLIT-REPLACE` and `ADD-Coordinator` are not emitted, and the caveat is stated. (Model-axis N/A is the core binding `{MODEL_AXIS_DEGRADES_UNDER}` — `never` for review; SPLIT-axis N/A is this injected instruction — both availability degradations reach the same core gate/synthesis sites through their own channel.)
+
+## Precondition
+
+This skill requires the preceding `/review` Step 3 reviewer composition to be in context. It is a `disable-model-invocation: true` second-opinion skill and does NOT auto-chain `/review`.
+
+**review-lite conflict guard**: if the in-context proposal looks like a `/review-lite` composition (fixed 2×sonnet — a dedicated security reviewer + a code-quality/logic reviewer; opus excluded; no Scope Coordinator; a single Y/N gate), both reinforcement axes conflict with the lite contract — UPGRADE→opus violates the sonnet pin, and ADD/SPLIT/ADD-Coordinator mutate the fixed 2-member roster (ADD-Coordinator also contradicts "no Scope Coordinator"). Emit a Korean caveat and proceed only on explicit user confirmation; otherwise recommend `/cc-cmds:review`. (Consistent with the cross-reference in `review-lite/SKILL.md`.)
+
+**Schema-drift sync note**: the source of truth is `/review` Step 3's reviewer-composition field set (`역할 | 모델 | 담당 범위` — Korean table). If Step 3 changes that field set, manually sync this skill's OPERATION Korean labels and model aliases. Because this skill's labels are **verbatim-equal** to the Step 3 table headers (design-upgrade's are a conceptual translation of English prose), the drift coupling is tighter — a header rename in Step 3 breaks the verbatim match directly. Do NOT touch `review/SKILL.md`. The residual risk of a missed sync is accepted without a lint (single-direction, one (consumer, source-step) pair).
+
+## Fallback
+
+When the precondition is not met, follow a 3-path fallback. The re-feed target is path-conditional — emit a per-path "재투입 대상" note so the user does not paste back into the wrong slot.
+
+- **Path 1 — session roster paste** (full two-axis): the user pastes the Step 3 `역할 | 모델 | 담당 범위` table → full two-axis analysis. This path uniquely still holds Step 3's `위험 신호` directly, the freshest reconciliation input. **재투입 대상**: `/review` Step 3 re-proposal (prospective).
+
+- **Path 2 — reverse-engineer from a saved review report** (model + perspective-ADD axes complete; quantitative SPLIT / Coordinator degraded): unlike design, `docs/reviews/<report>.md` `## 개요`'s `리뷰 팀 구성` preserves all three axes as `역할 ([모델]): [담당 범위]` → the **model axis (UPGRADE) is fully restored**, and the perspective-gap `ADD` is restorable subject to the caveats below. But **the per-file quantitative signal is absent, so quantitative SPLIT and ADD-Coordinator gating degrade to N/A / suppressed** (see SPLIT-axis degradation above; symmetric to design Path-2's model-axis N/A). Caveats to state:
+    - (i) This is an AS-RUN roster (generated from the approved Step 3, possibly modified at Step 6 — retrospective), so it is followup-team information, not a live proposal.
+    - (ii) Step 3's `위험 신호` is not preserved → reconcile `ADD` from the report's `## 미검토 영역` (direct ADD input, but a **conditional section — may be omitted when not applicable**) + finding `[category]` tags + bounded diff re-read. When `## 미검토 영역` is absent, re-derive ADD from the secondary inputs (`[category]` tags + bounded re-read) alone; ADD input confidence is lower in that case, so "fully restored" holds **only when `## 미검토 영역` exists**.
+    - (iii) On multiple report versions, use the highest version.
+    - (iv) **Quantitative SPLIT and ADD-Coordinator suppressed** — Path-2 output is limited to UPGRADE + ADD (perspective gap).
+  - **재투입 대상**: `/review` Step 6 team re-creation (retrospective). Step 6 requires augmented fields (Re-creation reason / Previous review coverage / Additional analysis scope) + an approval cycle, not the Step 3 form, so there is no slot a `역할 | 모델 | 담당 범위` OPERATION drops into verbatim. Map the Path-2 output instead: the OPERATION roster delta (UPGRADE / ADD [/ ADD-Coordinator and SPLIT-REPLACE are suppressed on Path-2]) → Step 6 **Additional analysis scope** (plus the re-created roster); each ADD's rationale → Step 6 **Previous review coverage** (covered vs uncovered, citing the report's `## 미검토 영역`); **Re-creation reason** is supplied separately by the user / next-turn model (the emit does not force it). This keeps "paste back without ambiguity" aligned with Step 6's input schema.
+
+- **Path 3 — start a new `/review`**: when neither is available, two-axis analysis is impossible — emit a Korean notice (e.g., *"분석할 리뷰어 구성이 없습니다. 먼저 `/cc-cmds:review`를 실행해 Step 3 리뷰어 구성을 받은 뒤 다시 호출하세요."*) and stop.
+
+## OPERATION worked example
+
+Emit full-triple OPERATIONs in `역할 / 모델 / 담당 범위` order (paste-back parity with Step 3):
+
+```
+[ADD]
+- 역할 / 모델 / 담당 범위: 데이터 정합성 리뷰어 / sonnet / DB 마이그레이션·스키마 변경·트랜잭션 경계·정합성 제약
+- 근거: PR이 마이그레이션을 포함하나 Step 3가 PR 타입을 일반 기능으로 분류해 data-integrity indicator 미발화 → 어느 리뷰어의 담당 범위도 미커버
+- 기대 효과: 마이그레이션 정합성 회귀를 전담 관점으로 포착
+
+[UPGRADE]
+- 역할: 보안 전담 리뷰어
+- 현재 모델 → 권장 모델: sonnet → opus
+- 변경 사유: 멀티 서비스 인증 위임 경로의 크로스 도메인 추론이 opus 강점에 정합
+- 기대 효과: 미묘한 authn bypass 검출률 향상
+
+역할/모델 변경 불필요 (해당 시): 나머지 리뷰어는 현재 구성 유지 — 근거: ...
+```

--- a/scripts/lint-skill-invariants.sh
+++ b/scripts/lint-skill-invariants.sh
@@ -46,8 +46,10 @@ INVARIANT_HEADING='^## Control-Flow Invariants[[:space:]]*$'
 #     turn-yield contract that compaction could break.
 #   - Single-pass verdict-emit skills (design-ingest) — loop state recovered
 #     from `## Verdict:` headers on disk; every invocation is fresh-context.
-#   - Linear authoring skills (design-system / design-prompt / design-upgrade)
-#     — no loop at all, no termination contract to lose.
+#   - Linear authoring / single-pass second-opinion skills (design-system /
+#     design-prompt / design-upgrade / review-upgrade) — no loop at all, no
+#     termination contract to lose. review-upgrade is a single-pass, teamless,
+#     counterless second-opinion (same basis as design-upgrade).
 #   - IO orchestrators (active-notify / implement) — termination is a
 #     hook/tool-driven boundary, not a counter the model has to maintain.
 # In effect, the non-exempt members are the `design-review ↔ design-review-lite`
@@ -60,7 +62,7 @@ INVARIANT_HEADING='^## Control-Flow Invariants[[:space:]]*$'
 # could corrupt), `design-analyze` creates files while its source repo must stay
 # untouched, so a summarized-away read-only rule is a real silent-corruption
 # vector that first-5K placement guards against.
-EXEMPT_SKILLS=("active-notify" "design-upgrade" "implement" "review" "design-lite" "review-lite" "design-system" "design-prompt" "design-ingest" "design-apply")
+EXEMPT_SKILLS=("active-notify" "design-upgrade" "review-upgrade" "implement" "review" "design-lite" "review-lite" "design-system" "design-prompt" "design-ingest" "design-apply")
 
 # Resolve skills root (allow SKILLS_ROOT env override for tests).
 script_dir=$(cd "$(dirname "$0")" && pwd)


### PR DESCRIPTION
## 개요

`/review` Step 3 리뷰어 구성을 분석하는 **모델·역할 두 축 second-opinion 스킬 `review-upgrade`를 신설**한다. `design-upgrade`가 `/design` Step 2를 분석하는 것과 정확히 대칭으로, 직전 `/review` Step 3 구성에서 (a) opus 강점이 유의미한 리뷰어의 opus 승격, (b) 누락된 리뷰 관점을 메우는 신규 리뷰어 추가, (c) 과부하 리뷰어 분할을 짚어준다. 이를 위해 `design-upgrade`가 인라인으로 보유하던 두 축 강화 로직을 repo 최초의 **파라미터화된 `_common` 코어**로 추출하고, `design-upgrade`를 그 소비자로 리팩터(동작 동등)한 뒤 `review-upgrade`를 두 번째 소비자로 얹는다.

## 주요 변경

### 신규
- **`_common/team-upgrade-analysis.md`** — repo 최초의 파라미터화된 `_common` 코어. 축-불문 두 축 알고리즘(Scope·절제 원칙·4단계 역할-갭 탐지·HARD LIMIT·절제/분할 게이트·OPERATION 구조·per-existing-role 불변식·degraded-axis 처리·Cross-axis synthesis)을 리터럴 `{PLACEHOLDER}` + 3-채널 주입 인터페이스(`## Bindings` 값 치환 / `## Operations Layer` 규칙 append seam / 주입 prose)로 담는다.
- **`review-upgrade/SKILL.md`** — frontmatter + `## Bindings`(컬럼 순서 `역할 | 모델 | 담당 범위`) + `## Operations Layer`(ADD-Coordinator 2조건 게이트 + Path-2 suppress + `SPLIT-REPLACE`-Coordinator forbidden) + 역할 축 매핑(risk-indicator 4조건 화해) + SPLIT-축 N/A 주입 + 3-path Fallback(Path-2 → Step 6 augmented 필드 매핑) + review-lite 가드 + sync-note + OPERATION worked example.

### 수정
- **`design-upgrade/SKILL.md`** — 인라인 로직을 코어 self-read + `## Bindings`(design 값)로 치환. frontmatter 불변, 8개 결정 동작 동등.
- **`review-lite/SKILL.md`** — sonnet-pin bullet에 review-upgrade out-of-scope 명확화 reciprocal 1줄 추가(양방향 대칭).
- **`scripts/lint-skill-invariants.sh`** — `EXEMPT_SKILLS`에 `review-upgrade` 추가(single-pass second-opinion) + doc-comment 갱신.
- **`README.md`** / **`CHANGELOG.md`** / **`plugin.json`** — review-upgrade row 추가, `## [1.13.0]` entry, `1.12.0 → 1.13.0` bump.

## 검증
- lint 3종 통과 (options OK, invariants SKIP, paths pass), `make lint` 전체 green.
- README diff = review-upgrade 추가만으로 한정 (design-upgrade·review-lite row byte-불변).