### PR TITLE
fix(design-review): 리뷰 에이전트 모델을 세션 모델 상속으로 고정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to cc-cmds are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 2026-06-09
+
+`design-review`가 inner-loop 리뷰 에이전트를 spawn할 때 리뷰 모델이 실행마다 비결정적으로 선택되던 문제를 고친다. 근본 원인은 상속 실패가 아니라 Step 12 spawn 지시가 underspecified라는 것 — `Agent()`에 `model`을 비우면 하네스 부모 상속이 건전하게 작동하지만, 스킬이 아무 지시도 없어 오케스트레이팅 메인루프가 일부 spawn에 `model` override를 임의 주입한다. 리뷰 모델을 **세션 모델 상속(inherit)**으로 고정해, 리뷰 깊이·비용이 사용자의 세션(=비용) 선택을 결정적으로 추적하도록 한다 (저비용 플랜 사용자에게 opus 하드핀은 매 실행 큰 초과비용이었다). 범위는 `design-review`만이며 `design-review-lite`(sonnet 하드핀)는 불변이다 (`/plugin update cc-cmds`로 자동 반영).
+
+### Fixed
+
+- **`design-review` Step 12 리뷰 에이전트 모델 비결정성**: 리뷰 에이전트 `Agent()` 호출이 `model` 파라미터를 **반드시 생략**하도록 omit+bind 지시를 추가한다. 생략 시 하네스 부모 상속이 세션 모델을 그대로 물려받아 세션 내 결정적이며, 세션 모델을 명시적 리터럴로 주입하는 것을 금지해(sonnet/haiku 메인루프가 자기 티어를 명시 주입하는) 역방향 drift를 차단한다. 이 bind는 prose로만 강제하며, 향후 리터럴 주입 재개 잔여 drift 리스크는 위임-판단-잔여 norm에 따라 명시 수용한다(상시 모니터링 hook 미설치).
+
+### Changed
+
+- **haiku 가시성 best-effort notice**: 세션 첫 리뷰 에이전트 spawn 직전, 메인 세션이 자기 세션 모델을 haiku로 판단하면 세션당 1회 한국어 prose 1줄을 emit해 "터미널 설계 게이트가 haiku로 실행 중 — 발견이 얕을 수 있음(sonnet/opus 세션 재실행 권장)"을 알린다. floor(동작 변경)가 아니라 정보 제공이며 self-ID 의존 best-effort라 미발화는 현상유지(benign)다. haiku는 명시 선택으로만 도달하므로 대상은 항상 cheapest를 의도 선택한 사용자다.
+- **`## Constraints` 상속 정책 1줄**: 리뷰 에이전트가 세션 모델을 상속한다는 정책을 Constraints에 재기술한다(`design-review-lite`의 sonnet 하드핀 constraint와 대칭 — full은 티어를 고정하지 않고 상속).
+
 ## [1.16.0] - 2026-06-08
 
 `design` 스킬 Step 4에 **synthesis fidelity pass(충실도 점검)**를 도입한다. 리드가 모든 토론을 압축해 문서를 작성하는 과정에서 발생하는 누락·왜곡·약화는 원본 컨텍스트 보유자(팀원)만 잡을 수 있고, 저장 직후 team-cleanup으로 컨텍스트가 소실되면 다운스트림 `design-review`가 원리적으로 감지하지 못한다. 따라서 cleanup 이전·pre-save sweep 직전의 살아있는 Step 3 팀으로만 가능한 고유 검사를 추가해 합성 충실도 결함 클래스를 메운다 (`/plugin update cc-cmds`로 자동 반영).

--- a/plugins/cc-cmds/.claude-plugin/plugin.json
+++ b/plugins/cc-cmds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "cc-cmds",
     "description": "Engineering workflow commands for Claude Code",
-    "version": "1.16.0",
+    "version": "1.16.1",
     "author": { "name": "Nano" },
     "keywords": [
         "design",

--- a/plugins/cc-cmds/skills/design-review/SKILL.md
+++ b/plugins/cc-cmds/skills/design-review/SKILL.md
@@ -365,7 +365,9 @@ The review agent prompt instructs it to read the `## Acknowledged Items` section
 
 Perform agent-based iterative review until severity saturation (§3.11). Each round spawns a **fresh** review agent that independently reviews the document from scratch.
 
-**Step 12** — `inner_round += 1`. Spawn a review agent.
+**Step 12** — `inner_round += 1`. Spawn a review agent. **The review agent's `Agent()` call MUST omit the `model` parameter** — the harness's parent inheritance then passes the orchestrating session model straight through, so the review model is deterministic within a session and tracks the user's cost choice. Do NOT inject the session model as an explicit literal: a sonnet/haiku main loop helpfully naming its own tier would create reverse drift. This bind is prose-enforced only; the residual drift risk of a future orchestrator resuming literal injection is an interpretable model misjudgment, explicitly accepted per the repo's delegated-judgment-residual norm (no always-on monitoring hook).
+
+**haiku 가시성 notice (best-effort, 세션당 1회)**: 세션의 첫 리뷰 에이전트 spawn 직전(즉 `outer_iter == 1` 그리고 `inner_round == 1`인 시점)에, 메인 세션이 자기 세션 모델을 haiku로 판단하면 한국어 prose 1줄을 emit한다 — 예: "⚠️ 터미널 설계 게이트가 haiku 모델로 실행 중입니다 — 발견이 얕을 수 있습니다. 더 깊은 리뷰가 필요하면 sonnet/opus 세션에서 재실행하세요." 이는 floor(동작 변경)가 아니라 정보 제공이며 모델 self-ID에 의존하는 best-effort다: 미발화는 현상유지(benign — 다운그레이드 경로 없음)다. haiku는 명시적 `/model haiku`·`--model haiku`·`ANTHROPIC_MODEL=haiku`로만 도달하므로, notice의 대상은 항상 세션 전체를 cheapest로 의도 선택한 사용자다.
 
 **Before spawning the review agent, Read `${CLAUDE_SKILL_DIR}/references/06-review-agent-prompt.md`** and substitute `{TEMP_DIR}` (= actual `INNER_TEMP_DIR`), `{USER_NOTE}` (the trailing note when non-empty, else empty), `{BASE_MODE_CONSTRAINT}` (the `--base` block when `BASE_MODE=true`, else empty), and `{CHANGES_MODE_CONSTRAINT}` (the `--changes` block when `CHANGES_MODE=true`, else empty) per the file's substitution contract, then prepend the path context block before calling `Agent()`.
 
@@ -752,6 +754,8 @@ Flag parsing is done together with `--base` in Phase 1 step 2 (all three flags a
 ## Constraints
 
 - **Deferred tool loading**: Before using AskUserQuestion, you MUST first load it via `ToolSearch("select:AskUserQuestion")` before any user prompt step. **Before calling AskUserQuestion, Read `${CLAUDE_SKILL_DIR}/../_common/askuserquestion.md`.** Apply the hard constraints from that file to every AskUserQuestion call in this skill.
+
+- **Review agent model (session inheritance)**: every inner-loop review agent inherits the orchestrating session model — the `Agent()` call omits the `model` parameter and never injects an explicit literal (see Step 12). This keeps the review model deterministic within a session and tracks the user's cost choice. It is the inverse of `design-review-lite`, which hard-pins `sonnet`: full design-review inherits the tier instead of fixing one.
 
 ## Begin
 


### PR DESCRIPTION
## 무엇

`design-review`의 inner-loop 리뷰 에이전트 모델이 실행마다 비결정적으로 선택되던 문제를 고친다. 리뷰 모델을 **오케스트레이팅 세션 모델 상속(inherit)**으로 고정한다.

## 왜

리뷰 에이전트 spawn 지시(Step 12)가 `model`을 지정하지 않아, 오케스트레이팅 메인루프가 일부 spawn에 `model` override를 임의 주입했다. 그 결과 같은 문서·같은 세션이라도 리뷰 모델이 실행마다 달라졌다(omit/opus/sonnet 혼재). 근본 원인은 하네스 상속 실패가 아니라 지시의 underspecification이다 — `Agent()`에서 `model`을 비우면 부모 세션 모델이 그대로 상속된다.

리뷰 모델이 사용자의 세션(=비용) 선택을 결정적으로 추적하는 것이 바람직하다. 저비용 플랜 사용자에게 opus 하드핀은 매 실행 큰 초과비용이고, 세션 내 모델 고정이라 상속은 결정적이다(같은 문서+같은 세션 → 같은 모델).

## 변경

- **Step 12 omit+bind**: 리뷰 에이전트 `Agent()` 호출이 `model` 파라미터를 반드시 생략하도록 지시 추가. 세션 모델을 명시 리터럴로 주입하는 것을 금지해 sonnet/haiku 메인루프가 자기 티어를 명시 주입하는 역방향 drift를 차단한다. prose 강제이며, 잔여 drift 리스크는 위임-판단-잔여 norm에 따라 명시 수용(상시 모니터링 hook 미설치).
- **haiku best-effort notice**: haiku 세션의 첫 리뷰 spawn 직전 세션당 1회 한국어 1줄로 "얕은 리뷰 가능성·sonnet/opus 재실행"을 안내. floor(동작 변경)가 아닌 정보 제공이며 self-ID 의존이라 미발화 시 현상유지(benign).
- **Constraints 1줄**: 상속 정책 재기술. `design-review-lite`의 sonnet 하드핀과 대칭(full은 티어 고정 대신 상속).
- 버전 `1.16.1` bump + CHANGELOG.

## 범위

`design-review`만. `design-review-lite`(sonnet 하드핀)·design-ingest·design-apply는 불변.

## 검증

비-opus(sonnet) 세션에서 design-review 1회 실행 → 리뷰 에이전트 spawn 13/13이 `model`을 생략했고 spawn된 subagent가 전부 세션 동티어(sonnet)로 실행됨을 transcript 교차 확인. 생략→동티어 상속이 비-opus 세션에서도 성립함을 직접 관측.