### PR TITLE
chore(marketplace): 플러그인 버전 드리프트 수정 + 재발 방지 lint 게이트

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,7 @@
         {
             "name": "cc-cmds",
             "source": "./plugins/cc-cmds",
-            "description": "Engineering workflow commands for Claude Code",
-            "version": "1.1.0"
+            "description": "Engineering workflow commands for Claude Code"
         }
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ lint:
 	@jq empty plugins/cc-cmds/hooks/hooks.json
 	@test -x plugins/cc-cmds/hooks/active-notify-pretool.sh
 	@grep -qE "terminal-notifier[[:space:]].*-group[[:space:]]['\"]cc-cmds-active-notify['\"]" plugins/cc-cmds/skills/active-notify/SKILL.md || (echo "lint: SKILL.md §7 bypass single-line contract violated (terminal-notifier + -group [quoted]cc-cmds-active-notify[quoted] must be on the same line for bypass_re to match)" >&2; exit 1)
+	@jq -e 'has("version")' plugins/cc-cmds/.claude-plugin/plugin.json >/dev/null || (echo "lint: plugin.json must have a .version field (it is the single version SOT)" >&2; exit 1)
+	@jq -e '[.plugins[] | has("version")] | any | not' .claude-plugin/marketplace.json >/dev/null || (echo "lint: marketplace.json plugin entries must NOT declare .version (plugin.json is the version SOT)" >&2; exit 1)
 
 readme:
 	bash scripts/generate-readme.sh


### PR DESCRIPTION
## 배경

`.claude-plugin/marketplace.json`의 플러그인 엔트리 `version`이 `1.1.0`, `plugins/cc-cmds/.claude-plugin/plugin.json`의 `version`이 `1.20.1`로 약 19개 마이너 버전 벌어져 있었다(최상위 marketplace 메타에는 `version` 필드 없음). bump 규칙이 plugin.json만 갱신해 왔고 marketplace 엔트리의 중복 `version`은 초기값에 방치된 결과다. 두 필드가 공존해 서로 갈라질 수 있는 구조 자체가 원인이다.

## 변경

- **marketplace.json**: 플러그인 엔트리의 `version` 필드 삭제. `version`이 엔트리의 마지막 키라 그 줄만 지우면 앞줄 `description`의 후행 쉼표가 dangling comma로 남으므로, 2줄 블록을 쉼표 없는 `description` 한 줄로 치환. 삭제 후 유효 버전은 plugin.json의 `1.20.1`이 단독 결정한다(figma·frontend-design 등 다른 플러그인이 이미 엔트리 version 생략 경로로 동작).
- **Makefile `lint:`**: 기존 인라인 게이트와 동종의 jq 게이트 2줄 추가.
  - Gate 1 — plugin.json은 `.version`을 **가져야** 함(역방향 삭제로 유효 버전이 `unknown`이 되는 사고 방지).
  - Gate 2 — marketplace 엔트리는 `.version`을 **가지면 안 됨**(엔트리 0개·다수 모두 견고).

게이트가 막는 것이 정확히 이 PR이 고치는 결함(엔트리 version 재유입)의 재발이므로 수정과 한 몸이다.

## 검증

- `make lint` 전체 green(신규 게이트 2종 포함).
- 수정 전 원본에서 Gate 2가 드리프트를 정확히 포착(exit 1), 수정 후 통과(exit 0).
- `make check`의 README staleness 없음(스킬 메타 무변경).

## 비고

- bump 없음 — 스킬 런타임 동작을 바꾸지 않아 bump 규칙 대상이 아니다(`chore`). CHANGELOG entry 불필요.